### PR TITLE
rewrite stm32f103 flash driver using registers instead of stm32cubeMX generated HAL drivers

### DIFF
--- a/libparams/flash_driver.h
+++ b/libparams/flash_driver.h
@@ -18,9 +18,10 @@
 extern "C" {
 #endif
 
-void flashUnlock();
-void flashLock();
 
+/**
+ * @brief Do nothing at the moment, but reserved for future possible updates
+ */
 void flashInit();
 
 /**
@@ -31,14 +32,20 @@ void flashInit();
 int8_t flashErase(uint32_t start_page_idx, uint32_t num_of_pages);
 
 /**
+ * @brief Before writing you must call flashUnlock(), after writing you must call flashLock()
+ * @param[in] address - actual address on flash memory
+ * @param[in] data - 64 bit of data
  * @return 0 if success, otherwise < 0
  */
+void flashUnlock();
 int8_t flashWriteU64(uint32_t address, uint64_t data);
+void flashLock();
 
 /**
+ * @brief Read chunk of data like memcpy
  * @return bytes_to_read if success, otherwise 0
  */
-size_t flashMemcpy(uint8_t* data, size_t offset, size_t bytes_to_read);
+size_t flashRead(uint8_t* data, size_t offset, size_t bytes_to_read);
 
 /**
  * @return Info about the flash memory

--- a/libparams/rom.c
+++ b/libparams/rom.c
@@ -49,7 +49,7 @@ size_t romRead(const RomDriverInstance* rom, size_t offset, uint8_t* data, size_
         bytes_to_read = requested_size;
     }
 
-    return flashMemcpy(data, rom->first_page_idx * flashGetPageSize() + offset, bytes_to_read);
+    return flashRead(data, rom->first_page_idx * flashGetPageSize() + offset, bytes_to_read);
 }
 
 void romBeginWrite(const RomDriverInstance* rom) {

--- a/platform_specific/stm32f103/flash_driver.c
+++ b/platform_specific/stm32f103/flash_driver.c
@@ -8,20 +8,34 @@
 
 #include "flash_driver.h"
 #include <string.h>
-#include "main.h"
 #include "libparams_error_codes.h"
+#include "flash_registers.h"
+
+
+#define FLASH_TIMEOUT_VALUE     50000U
+#define FLASH_MAX_DELAY         0xFFFFFFFFU
+
+#define SET_BIT(REG, BIT)       ((REG) |= (BIT))
+#define CLEAR_BIT(REG, BIT)     ((REG) &= ~(BIT))
+#define WRITE_REG(REG, VAL)     ((REG) = (VAL))
+
+uint32_t HAL_GetTick();
 
 static uint8_t* flashGetPointer();
+static int8_t flashWaitForLastOperation(uint32_t timeout);
+static void flashPageErase(uint32_t page_address);
+static void flashProgramHalfWord(uint32_t address, uint16_t data);
 
 
 void flashInit() {
 }
 
 void flashUnlock() {
-    HAL_FLASH_Unlock();
+    WRITE_REG(FLASH->KEYR, FLASH_KEYR_KEY1);
+    WRITE_REG(FLASH->KEYR, FLASH_KEYR_KEY2);
 }
 void flashLock() {
-    HAL_FLASH_Lock();
+    SET_BIT(FLASH->CR, FLASH_CR_LOCK);
 }
 
 /**
@@ -31,16 +45,23 @@ void flashLock() {
  * @note from https://www.st.com/resource/en/datasheet/stm32f103c8.pdf
  */
 int8_t flashErase(uint32_t start_page_idx, uint32_t num_of_pages) {
-    uint32_t page_address = FLASH_START_ADDR + flashGetPageSize() * start_page_idx;
-    FLASH_EraseInitTypeDef FLASH_EraseInitStruct = {
-        .TypeErase = FLASH_TYPEERASE_PAGES,
-        .Banks = 0,
-        .PageAddress = (uint32_t)page_address,
-        .NbPages = num_of_pages
-    };
-    uint32_t page_error = 0;
-    HAL_FLASHEx_Erase(&FLASH_EraseInitStruct, &page_error);
-    return (page_error == 0xFFFFFFFF) ? 0 : -1;
+    if (flashWaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE) != 0) {
+        return -1;
+    }
+
+    int8_t status = -1;
+    uint32_t first_page_address = FLASH_START_ADDR + FLASH_PAGE_SIZE * start_page_idx;
+    uint32_t last_page_address = first_page_address + (num_of_pages * FLASH_PAGE_SIZE);
+    for (uint32_t addr = first_page_address; addr < last_page_address; addr += FLASH_PAGE_SIZE) {
+        flashPageErase(addr);
+        status = flashWaitForLastOperation((uint32_t)FLASH_TIMEOUT_VALUE);
+        CLEAR_BIT(FLASH->CR, FLASH_CR_PER);
+        if (status != 0) {
+            break;
+        }
+    }
+
+    return status;
 }
 
 /**
@@ -51,15 +72,31 @@ int8_t flashErase(uint32_t start_page_idx, uint32_t num_of_pages) {
  * @note from https://www.st.com/resource/en/datasheet/stm32f103c8.pdf
  */
 int8_t flashWriteU64(uint32_t address, uint64_t data) {
-    HAL_StatusTypeDef hal_status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, address, data);
-    return (hal_status != HAL_OK) ? -1 : 0;
+    int8_t status = flashWaitForLastOperation(FLASH_TIMEOUT_VALUE);
+
+    if (status < 0) {
+        return status;
+    }
+
+    for (uint8_t index = 0U; index < 4; index++) {
+        flashProgramHalfWord((address + (2U*index)), (uint16_t)(data >> (16U*index)));
+
+        status = flashWaitForLastOperation(FLASH_TIMEOUT_VALUE);
+
+        CLEAR_BIT(FLASH->CR, FLASH_CR_PG);
+        if (status < 0) {
+            break;
+        }
+    }
+
+    return status;
 }
 
 static uint8_t* flashGetPointer() {
     return (uint8_t*) FLASH_START_ADDR;
 }
 
-size_t flashMemcpy(uint8_t* data, size_t offset, size_t bytes_to_read) {
+size_t flashRead(uint8_t* data, size_t offset, size_t bytes_to_read) {
     if (data == NULL) {
         return 0;
     }
@@ -74,9 +111,42 @@ uint16_t flashGetNumberOfPages() {
 }
 
 uint16_t flashGetPageSize() {
-    return 1024;
+    return FLASH_PAGE_SIZE;
 }
 
 uint8_t flashGetWordSize() {
-    return 4;
+    return 8;
+}
+
+static int8_t flashWaitForLastOperation(uint32_t timeout) {
+    uint32_t tickstart = HAL_GetTick();
+
+    while (FLASH->SR & FLASH_SR_BSY) {
+        if (timeout != FLASH_MAX_DELAY) {
+            if ((timeout == 0U) || ((HAL_GetTick() - tickstart) > timeout)) {
+                return -3;
+            }
+        }
+    }
+
+    if (FLASH->SR & FLASH_SR_EOP) {
+        FLASH->SR = FLASH_SR_EOP;
+    }
+
+    if (FLASH->SR & (FLASH_SR_WRPRTERR | FLASH_SR_PGERR) || FLASH->OBR & FLASH_OBR_OPTERR) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static void flashPageErase(uint32_t page_address) {
+    SET_BIT(FLASH->CR, FLASH_CR_PER);
+    WRITE_REG(FLASH->AR, page_address);
+    SET_BIT(FLASH->CR, FLASH_CR_STRT);
+}
+
+static void flashProgramHalfWord(uint32_t address, uint16_t data) {
+    SET_BIT(FLASH->CR, FLASH_CR_PG);
+    *(volatile uint16_t*)address = data;
 }

--- a/platform_specific/stm32f103/flash_registers.h
+++ b/platform_specific/stm32f103/flash_registers.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Dmitry Ponomarev <ponomarevda96@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Reference: https://www.st.com/resource/en/programming_manual/pm0075-
+ * stm32f10xxx-flash-memory-microcontrollers-stmicroelectronics.pdf
+ */
+
+#ifndef PLATFORM_SPECIFIC_STM32F103TB_FLASH_REGISTERS_H_
+#define PLATFORM_SPECIFIC_STM32F103TB_FLASH_REGISTERS_H_
+
+// STM32F103TB constants
+#define FLASH_PAGE_SIZE 1024
+
+// Flash memory interface registers (medium-density devices)
+typedef struct {
+    volatile uint32_t ACR;          ///< 0x4002 2000 - 0x4002 2003
+    volatile uint32_t KEYR;         ///< 0x4002 2004 - 0x4002 2007
+    volatile uint32_t OPTKEYR;      ///< 0x4002 2008 - 0x4002 200B
+    volatile uint32_t SR;           ///< 0x4002 200C - 0x4002 200F
+    volatile uint32_t CR;           ///< 0x4002 2010 - 0x4002 2013
+    volatile uint32_t AR;           ///< 0x4002 2014 - 0x4002 2017
+    volatile uint32_t RESERVED;     ///< 0x4002 2018 - 0x4002 201B
+    volatile uint32_t OBR;          ///< 0x4002 201C - 0x4002 201F
+    volatile uint32_t WRPR;         ///< 0x4002 2020 - 0x4002 2023
+} FlashMemoryInterfaceRegisters;
+
+#define FLASH ((FlashMemoryInterfaceRegisters *)0x40022000UL)
+
+// 3.2 FPEC key register (FLASH_KEYR)
+#define FLASH_KEYR_KEY1         0x45670123UL
+#define FLASH_KEYR_KEY2         0xCDEF89ABUL
+
+// 3.4 Flash status register (FLASH_SR)
+#define FLASH_SR_BSY            (1 << 0)    // This indicates that a Flash operation is in progress
+#define FLASH_SR_PGERR          (1 << 2)    // Programming error
+#define FLASH_SR_WRPRTERR       (1 << 4)    // Write protection error
+#define FLASH_SR_EOP            (1 << 5)    // End of operation
+
+// 3.5 Flash control register (FLASH_CR)
+#define FLASH_CR_LOCK           (1 << 7)
+#define FLASH_CR_PER            (1 << 1)
+#define FLASH_CR_PG             (1 << 0)
+#define FLASH_CR_STRT           (1 << 6)
+
+// 3.7 Option byte register (FLASH_OBR)
+#define FLASH_OBR_OPTERR        (1 << 0)
+
+#endif  // PLATFORM_SPECIFIC_STM32F103TB_FLASH_REGISTERS_H_

--- a/platform_specific/stm32g0b1/flash_driver.c
+++ b/platform_specific/stm32g0b1/flash_driver.c
@@ -65,7 +65,7 @@ static uint8_t* flashGetPointer() {
     return (uint8_t*) FLASH_START_ADDR;
 }
 
-size_t flashMemcpy(uint8_t* data, size_t offset, size_t bytes_to_read) {
+size_t flashRead(uint8_t* data, size_t offset, size_t bytes_to_read) {
     if (data == NULL) {
         return 0;
     }

--- a/platform_specific/ubuntu/flash_driver.cpp
+++ b/platform_specific/ubuntu/flash_driver.cpp
@@ -97,7 +97,7 @@ static uint8_t* flashGetPointer() {
     return (uint8_t*) flash_memory;
 }
 
-size_t flashMemcpy(uint8_t* data, size_t offset, size_t bytes_to_read) {
+size_t flashRead(uint8_t* data, size_t offset, size_t bytes_to_read) {
     assert(data != NULL && "libparams internal error");
     assert(offset < PAGE_SIZE_BYTES && "ROM driver accessing non-existent mem");
     assert(bytes_to_read <= PAGE_SIZE_BYTES && "ROM driver accessing non-existent mem");

--- a/tests/platform_specific/stm32f103/main.c
+++ b/tests/platform_specific/stm32f103/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 Dmitry Ponomarev <ponomarevda96@gmail.com>
+ * Copyright (c) 2022-2024 Dmitry Ponomarev <ponomarevda96@gmail.com>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -7,52 +7,7 @@
  */
 
 #include "main.h"
-#include <stdbool.h>
-#include <string.h>
 
-#define PAGE_SIZE 1024
-static uint8_t flash_memory[PAGE_SIZE];
-static bool is_locked = true;
-static size_t initial_addr = 0x08000000;
-
-void HAL_FLASH_Init(uint32_t new_initial_addr) {
-    initial_addr = new_initial_addr;
-}
-
-HAL_StatusTypeDef HAL_FLASH_Unlock(void) {
-    if (!is_locked) {
-        return HAL_ERROR;
-    }
-    is_locked = false;
-    return HAL_OK;
-}
-
-HAL_StatusTypeDef HAL_FLASH_Lock(void) {
-    if (is_locked) {
-        return HAL_ERROR;
-    }
-    is_locked = true;
-    return HAL_OK;
-}
-
-HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t *PageError) {
-    if (pEraseInit->TypeErase != FLASH_TYPEERASE_PAGES ||
-            pEraseInit->PageAddress != initial_addr ||
-            pEraseInit->NbPages != 1) {
-        return HAL_ERROR;
-    }
-    memset((void*)flash_memory, 0x00, PAGE_SIZE);
-    return HAL_OK;
-}
-
-HAL_StatusTypeDef HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint64_t Data) {
-    if (TypeProgram != FLASH_TYPEPROGRAM_DOUBLEWORD ||
-            Address < initial_addr ||
-            Address % 4 != 0 ||
-            Address >= initial_addr + PAGE_SIZE) {
-        return HAL_ERROR;
-    }
-    size_t offset = Address - initial_addr;
-    flash_memory[offset] = (uint32_t)Data;
-    return HAL_OK;
+uint32_t HAL_GetTick() {
+    return 0;
 }

--- a/tests/platform_specific/stm32f103/main.h
+++ b/tests/platform_specific/stm32f103/main.h
@@ -9,31 +9,8 @@
 #ifndef STM32F1XX_HAL_MOCK_H_
 #define STM32F1XX_HAL_MOCK_H_
 
-#define FLASH_TYPEERASE_PAGES         0x00U
-#define FLASH_TYPEPROGRAM_DOUBLEWORD  0x03U
-
 #include <stdint.h>
 
-typedef enum
-{
-  HAL_OK       = 0x00U,
-  HAL_ERROR    = 0x01U,
-  HAL_BUSY     = 0x02U,
-  HAL_TIMEOUT  = 0x03U
-} HAL_StatusTypeDef;
-
-typedef struct
-{
-  uint32_t TypeErase;
-  uint32_t Banks;
-  uint32_t PageAddress;
-  uint32_t NbPages;
-} FLASH_EraseInitTypeDef;
-
-void HAL_FLASH_Init(uint32_t initial_addr);
-HAL_StatusTypeDef HAL_FLASH_Unlock(void);
-HAL_StatusTypeDef HAL_FLASH_Lock(void);
-HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t *PageError);
-HAL_StatusTypeDef HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint64_t Data);
+uint32_t HAL_GetTick();
 
 #endif  // STM32F1XX_HAL_MOCK_H_

--- a/tests/platform_specific/stm32g0b1/main.c
+++ b/tests/platform_specific/stm32g0b1/main.c
@@ -15,6 +15,10 @@ static uint8_t flash_memory[PAGE_SIZE];
 static bool is_locked = true;
 static size_t initial_addr = 0x08000000;
 
+uint32_t HAL_GetTick() {
+    return 0;
+}
+
 void HAL_FLASH_Init(uint32_t new_initial_addr) {
     initial_addr = new_initial_addr;
 }

--- a/tests/platform_specific/stm32g0b1/main.h
+++ b/tests/platform_specific/stm32g0b1/main.h
@@ -32,6 +32,7 @@ typedef struct
   uint32_t NbPages;
 } FLASH_EraseInitTypeDef;
 
+uint32_t HAL_GetTick();
 void HAL_FLASH_Init(uint32_t initial_addr);
 HAL_StatusTypeDef HAL_FLASH_Unlock(void);
 HAL_StatusTypeDef HAL_FLASH_Lock(void);


### PR DESCRIPTION
- flash driver interface has been rewriten, so now we have a single libparams/flash_driver.h header instead of keeping a separate one for each platform
- stm32f103 flash driver has been rewritten, so now it is more efficient and doesn't depend on stm32cubeMX HAL drivers