### PR TITLE
Pr refactor yaml params

### DIFF
--- a/platform_specific/ubuntu/FlashMemoryLayout.hpp
+++ b/platform_specific/ubuntu/FlashMemoryLayout.hpp
@@ -20,10 +20,10 @@ typedef struct {
 } ParametersLayout_t;
 
 typedef struct {
-    const uint8_t* flash_memory;
+    const uint8_t* memory_ptr;
     uint16_t page_size;
-    uint8_t flash_pages_num;
-    uint32_t flash_size = page_size * flash_pages_num;
+    uint8_t num_pages;
+    uint32_t flash_size = page_size * num_pages;
 } FlashMemoryLayout_t;
 
 #endif  // LIBPARAM_FLASH_MEMORY_LAYOUT_HPP

--- a/platform_specific/ubuntu/FlashMemoryLayout.hpp
+++ b/platform_specific/ubuntu/FlashMemoryLayout.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Anastasiia Stepanova <asiiapine@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef LIBPARAM_FLASH_MEMORY_LAYOUT_HPP_
+#define LIBPARAM_FLASH_MEMORY_LAYOUT_HPP_
+
+#include "storage.h"
+
+typedef struct {
+    IntegerDesc_t* integer_desc_pool;
+    StringDesc_t* string_desc_pool;
+
+    uint8_t num_int_params;
+    uint8_t num_str_params;
+} ParametersLayout_t;
+
+typedef struct {
+    const uint8_t* flash_memory;
+    uint16_t page_size;
+    uint8_t flash_pages_num;
+    uint32_t flash_size = page_size * flash_pages_num;
+} FlashMemoryLayout_t;
+
+#endif  // LIBPARAM_FLASH_MEMORY_LAYOUT_HPP

--- a/platform_specific/ubuntu/SimpleLogger.hpp
+++ b/platform_specific/ubuntu/SimpleLogger.hpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Dmitry Ponomarev <ponomarevda96@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef LIBPARAM_SIMPLE_LOGGER_HPP_
+#define LIBPARAM_SIMPLE_LOGGER_HPP_
+#include <iostream>
+#include <sstream>
+
+class SimpleLogger {
+public:
+    explicit SimpleLogger(const char* module_name): module(module_name) {}
+    template <typename... Args>
+    void info(Args... args) {
+        std::stringstream ss;
+        (ss << ... << args);
+        std::cout << module << ": " << ss.str() << std::endl;
+    }
+
+    template <typename... Args>
+    void error(Args... args) {
+        std::stringstream ss;
+        (ss << ... << args);
+        std::cerr << module << ": " << ss.str() << std::endl;
+    }
+
+private:
+    const char* module;
+};
+
+#endif  // LIBPARAM_SIMPLE_LOGGER_HPP_

--- a/platform_specific/ubuntu/SimpleLogger.hpp
+++ b/platform_specific/ubuntu/SimpleLogger.hpp
@@ -8,6 +8,7 @@
 
 #ifndef LIBPARAM_SIMPLE_LOGGER_HPP_
 #define LIBPARAM_SIMPLE_LOGGER_HPP_
+
 #include <iostream>
 #include <sstream>
 

--- a/platform_specific/ubuntu/YamlParameters.cpp
+++ b/platform_specific/ubuntu/YamlParameters.cpp
@@ -15,19 +15,26 @@
 #include "libparams_error_codes.h"
 #include "YamlParameters.hpp"
 
-YamlParameters::YamlParameters(FlashMemoryLayout_t flash_desc, ParametersLayout_t params_desc) {
+YamlParameters::YamlParameters(FlashMemoryLayout_t flash_desc,
+                               ParametersLayout_t params_desc) {
+    char error_mesg[100];
     flash = flash_desc;
     params = params_desc;
-    if (flash.flash_memory == nullptr || flash.page_size < 4 || flash.flash_pages_num == 0) {
-        logger.error("Invalid arguments for constructor");
+    if (flash.memory_ptr == nullptr || flash.page_size < 4 || flash.num_pages == 0) {
+        throw std::invalid_argument("Invalid arguments for constructor");
     }
     uint32_t req_flash_size = params.num_int_params * 4 + 56 * params.num_str_params;
     if (flash.flash_size < req_flash_size) {
-        char error_mesg[100];
         snprintf(error_mesg, sizeof(error_mesg),
                  "Not enought flash size, needed: %d, provided: %d",
                  (int)req_flash_size, (int)flash.flash_size);
-        logger.error(error_mesg);
+        throw std::invalid_argument(error_mesg);
+    }
+    const char* last_int_name = params.integer_desc_pool[params.num_int_params - 1].name;
+    const char* last_str_name = params.string_desc_pool[params.num_str_params - 1].name;
+    if ((last_int_name == nullptr && params.num_int_params > 0) ||
+            (last_str_name == nullptr && params.num_str_params > 0)) {
+        throw std::invalid_argument("Wrong number of parameters");
     }
 }
 
@@ -56,7 +63,7 @@ int8_t YamlParameters::read_from_dir(const std::string& path) {
     uint8_t int_param_idx = 0;
     uint8_t str_param_idx = 0;
     // read params values for each page
-    for (uint8_t idx = 0; idx < flash.flash_pages_num; idx++) {
+    for (uint8_t idx = 0; idx < flash.num_pages; idx++) {
         std::ifstream params_storage_file;
 
         // check if temp file for the page already exists, else read from init file
@@ -105,7 +112,7 @@ int8_t YamlParameters::write_to_dir(const std::string& path) {
     // remember last written indexes
     uint8_t int_param_idx = 0;
     uint8_t str_param_idx = 0;
-    for (uint8_t idx = 0; idx < flash.flash_pages_num; idx++) {
+    for (uint8_t idx = 0; idx < flash.num_pages; idx++) {
         snprintf(file_name, sizeof(file_name), "%s/%s_%d.yaml",
                  path.c_str(), temp_file_name.c_str(), idx);
         std::ofstream params_storage_file;
@@ -119,7 +126,10 @@ int8_t YamlParameters::write_to_dir(const std::string& path) {
     }
     if (int_param_idx != params.num_int_params || str_param_idx != params.num_str_params) {
         logger.error("Number of parameters in the file isn't equal",
-                     " to the one specified in the constructor");
+                     " to the one specified in the constructor",
+                     "int real: ", (int)int_param_idx, " expected: ", (int)params.num_int_params,
+                     "\n",
+                     "str real: ", (int)str_param_idx, " expected: ", (int)params.num_str_params);
         return LIBPARAMS_WRONG_ARGS;
     }
     return LIBPARAMS_OK;
@@ -131,6 +141,7 @@ int8_t YamlParameters::__read_page(std::ifstream& params_storage_file, uint8_t* 
     std::string value;
 
     while (std::getline(params_storage_file, line)) {
+        logger.info(line);
         size_t delimiter_pos = line.find(':');
         if (delimiter_pos == std::string::npos) {
             continue;
@@ -146,12 +157,12 @@ int8_t YamlParameters::__read_page(std::ifstream& params_storage_file, uint8_t* 
                 return LIBPARAMS_WRONG_ARGS;
             }
             int32_t int_value = std::stoi(value);
-            memcpy((void*)(flash.flash_memory + 4 * (*int_param_idx)), &int_value, 4);
+            memcpy((void*)(flash.memory_ptr + 4 * (*int_param_idx)), &int_value, 4);
             *int_param_idx = *int_param_idx + 1;
         } catch (std::invalid_argument const& ex) {
-            int offset = flash.flash_pages_num * flash.page_size - MAX_STRING_LENGTH *
-                         (params.num_str_params - (*str_param_idx));
-            if (*str_param_idx > params.num_str_params) {
+            int offset = flash.flash_size - MAX_STRING_LENGTH *
+                         (params.num_str_params - (*str_param_idx ));
+            if (*str_param_idx + 1> params.num_str_params) {
                 logger.error("Wrong num_str_params\n");
                 return LIBPARAMS_WRONG_ARGS;
             }
@@ -165,9 +176,9 @@ int8_t YamlParameters::__read_page(std::ifstream& params_storage_file, uint8_t* 
                 return LIBPARAMS_WRONG_ARGS;
             }
 
-            memcpy((void*)(flash.flash_memory + offset), str_value.c_str(),
+            memcpy((void*)(flash.memory_ptr + offset), str_value.c_str(),
                    strlen(str_value.c_str()));
-            memcpy((void*)(flash.flash_memory + offset + strlen(str_value.c_str())), "\0", 1);
+            memcpy((void*)(flash.memory_ptr + offset + strlen(str_value.c_str())), "\0", 1);
             *str_param_idx = *str_param_idx + 1;
         }
     }
@@ -184,11 +195,11 @@ int8_t YamlParameters::__write_page(std::ofstream& params_storage_file, uint8_t*
 
     uint32_t n_bytes = 0;
     uint8_t param_idx = *int_param_idx;
+
     for (uint8_t index = param_idx; index < params.num_int_params; index++) {
-        std::stringstream buffer;
         int32_t int_param_value;
-        memcpy(&int_param_value, flash.flash_memory + index * 4, 4);
         const char* name = params.integer_desc_pool[index].name;
+        memcpy(&int_param_value, flash.memory_ptr + index * 4, 4);
         params_storage_file << std::left << std::setw(32) << name << ": "
                             << int_param_value << "\n";
         logger.info(std::left, std::setw(32), name, ":\t", int_param_value);
@@ -208,16 +219,16 @@ int8_t YamlParameters::__write_page(std::ofstream& params_storage_file, uint8_t*
         last_str_param_idx = prev_str_idx + available_str_params;
     }
     for (uint8_t index = prev_str_idx; index < last_str_param_idx; index++) {
-        std::stringstream buffer;
-        size_t offset = flash.flash_pages_num * flash.page_size -
-                        MAX_STRING_LENGTH * (params.num_str_params - index);
+        const char* name = params.string_desc_pool[index].name;
+        if (name == nullptr) {
+            return LIBPARAMS_OK;
+        }
+        size_t offset = flash.flash_size - MAX_STRING_LENGTH * (params.num_str_params - index);
 
-        std::string str_param_value(reinterpret_cast<char*>((void*)(flash.flash_memory + offset)),
+        std::string str_param_value(reinterpret_cast<char*>((void*)(flash.memory_ptr + offset)),
                                     MAX_STRING_LENGTH);
         auto str_end = str_param_value.find('\0');
         auto str_param = str_param_value.substr(0, str_end);
-        const char* name = params.string_desc_pool[index].name;
-
         params_storage_file << std::left << std::setw(32) << name << ": " << '"'
                             << str_param.c_str() << '"' << "\n";
         logger.info(std::left, std::setw(32), name, ":\t", '"', str_param.c_str(), '"');

--- a/platform_specific/ubuntu/YamlParameters.cpp
+++ b/platform_specific/ubuntu/YamlParameters.cpp
@@ -15,8 +15,21 @@
 #include "libparams_error_codes.h"
 #include "YamlParameters.hpp"
 
-extern IntegerDesc_t integer_desc_pool[];
-extern StringDesc_t string_desc_pool[];
+YamlParameters::YamlParameters(FlashMemoryLayout_t flash_desc, ParametersLayout_t params_desc) {
+    flash = flash_desc;
+    params = params_desc;
+    if (flash.flash_memory == nullptr || flash.page_size < 4 || flash.flash_pages_num == 0) {
+        logger.error("Invalid arguments for constructor");
+    }
+    uint32_t req_flash_size = params.num_int_params * 4 + 56 * params.num_str_params;
+    if (flash.flash_size < req_flash_size) {
+        char error_mesg[100];
+        snprintf(error_mesg, sizeof(error_mesg),
+                 "Not enought flash size, needed: %d, provided: %d\n",
+                 (int)req_flash_size, (int)flash.flash_size);
+        logger.error(error_mesg);
+    }
+}
 
 int8_t YamlParameters::set_init_file_name(std::string file_name) {
     if (file_name.empty()) {
@@ -43,28 +56,26 @@ int8_t YamlParameters::read_from_dir(const std::string& path) {
     uint8_t int_param_idx = 0;
     uint8_t str_param_idx = 0;
     // read params values for each page
-    for (uint8_t idx = 0; idx < flash_pages_num; idx++) {
+    for (uint8_t idx = 0; idx < flash.flash_pages_num; idx++) {
         std::ifstream params_storage_file;
 
         // check if temp file for the page already exists, else read from init file
         snprintf(file_name, sizeof(file_name), "%s/%s_%d.yaml",
-                                    path.c_str(), temp_file_name.c_str(), idx);
+                 path.c_str(), temp_file_name.c_str(), idx);
         params_storage_file.open(file_name, std::ios_base::in);
         if (!params_storage_file) {
-            std::cout << "YamlParameters: " << file_name <<
-                                                " could not be opened for reading!" << std::endl;
+            logger.info(file_name, " could not be opened for reading!");
             snprintf(file_name, sizeof(file_name), "%s/%s_%d.yaml",
-                        path.c_str(), init_file_name.c_str(), idx);
+                     path.c_str(), init_file_name.c_str(), idx);
             params_storage_file.open(file_name, std::ios_base::in);
             if (!params_storage_file) {
-                std::cout << "YamlParameters: " << file_name <<
-                                                " could not be opened for reading!" << std::endl;
+                logger.info(file_name, " could not be opened for reading!");
                 return LIBPARAMS_WRONG_ARGS;
             }
         }
+        logger.info("data read from ", file_name);
 
-        std::cout << "YamlParameters: data read from " << file_name << std::endl;
-        if ((int_param_idx > num_int_params) || (str_param_idx > num_str_params)) {
+        if ((int_param_idx > params.num_int_params) || (str_param_idx > params.num_str_params)) {
             break;;
         }
         res = __read_page(params_storage_file, &int_param_idx, &str_param_idx);
@@ -85,31 +96,31 @@ int8_t YamlParameters::write_to_dir(const std::string& path) {
     // remember last written indexes
     uint8_t int_param_idx = 0;
     uint8_t str_param_idx = 0;
-    for (uint8_t idx = 0; idx < flash_pages_num; idx++) {
+    for (uint8_t idx = 0; idx < flash.flash_pages_num; idx++) {
         snprintf(file_name, sizeof(file_name), "%s/%s_%d.yaml",
-                                    path.c_str(), temp_file_name.c_str(), idx);
+                 path.c_str(), temp_file_name.c_str(), idx);
         std::ofstream params_storage_file;
         params_storage_file.open(file_name, std::ios_base::out);
-        std::cout << "YamlParameters: save data to " << file_name << std::endl;
-
+        logger.info("save data to ", file_name);
         res = __write_page(params_storage_file, &int_param_idx, &str_param_idx);
         params_storage_file.close();
         if (res != LIBPARAMS_OK) {
             return res;
         }
     }
-    if (int_param_idx != num_int_params || str_param_idx != num_str_params) {
-        std::cout << "YamlParameters:" <<
-        "Number of parameters in the file isn't equal to the one specified in the constructor\n";
+    if (int_param_idx != params.num_int_params || str_param_idx != params.num_str_params) {
+        logger.error("Number of parameters in the file isn't equal",
+                     " to the one specified in the constructor\n");
         return LIBPARAMS_WRONG_ARGS;
     }
     return LIBPARAMS_OK;
 }
 
 int8_t YamlParameters::__read_page(std::ifstream& params_storage_file, uint8_t* int_param_idx,
-                                                                    uint8_t* str_param_idx){
+                                   uint8_t* str_param_idx) {
     std::string line;
     std::string value;
+
     while (std::getline(params_storage_file, line)) {
         size_t delimiter_pos = line.find(':');
         if (delimiter_pos == std::string::npos) {
@@ -117,23 +128,22 @@ int8_t YamlParameters::__read_page(std::ifstream& params_storage_file, uint8_t* 
         }
         value = line.substr(delimiter_pos + 1);
         try {
-            if (*int_param_idx > num_int_params) {
-                std::cout <<
-                    "YamlParameters: Got more integer params than defined by num_int_params\n";
+            if (*int_param_idx > params.num_int_params) {
+                logger.error("Got more integer params than defined by num_int_params\n");
                 return LIBPARAMS_WRONG_ARGS;
             }
-            if (flash_size < 4 * (*int_param_idx)) {
-                std::cout << "YamlParameters: Not enought flash size\n";
+            if (flash.flash_size < 4 * (*int_param_idx)) {
+                logger.error("Not enought flash size\n");
                 return LIBPARAMS_WRONG_ARGS;
             }
             int32_t int_value = std::stoi(value);
-            memcpy(flash_memory + 4 * (*int_param_idx), &int_value, 4);
+            memcpy((void*)(flash.flash_memory + 4 * (*int_param_idx)), &int_value, 4);
             *int_param_idx = *int_param_idx + 1;
         } catch (std::invalid_argument const& ex) {
-            int offset = flash_pages_num * page_size - MAX_STRING_LENGTH *
-                                                        (num_str_params - (*str_param_idx));
-            if (*str_param_idx > num_str_params) {
-                std::cout << "YamlParameters: Wrong num_str_params";
+            int offset = flash.flash_pages_num * flash.page_size - MAX_STRING_LENGTH *
+                         (params.num_str_params - (*str_param_idx));
+            if (*str_param_idx > params.num_str_params) {
+                logger.error("Wrong num_str_params\n");
                 return LIBPARAMS_WRONG_ARGS;
             }
 
@@ -141,77 +151,77 @@ int8_t YamlParameters::__read_page(std::ifstream& params_storage_file, uint8_t* 
             size_t quote_end_pos = value.find('"', quote_pos + 1);
             std::string str_value = value.substr(quote_pos + 1, quote_end_pos - quote_pos - 1);
             if (offset < *int_param_idx * 4) {
-                char error_mesg[100];
-                snprintf(error_mesg, sizeof(error_mesg),
-                    "YamlParameters: params overlap last int param addr %d, str param offset %d\n",
-                    *int_param_idx * 4, offset);
-                std::cout << error_mesg;
+                logger.error("params overlap last int param addr", *int_param_idx * 4,
+                             ", str param offset ", offset, "\n");
                 return LIBPARAMS_WRONG_ARGS;
             }
 
-            memcpy(flash_memory + offset, str_value.c_str(), strlen(str_value.c_str()));
-            memcpy(flash_memory + offset + strlen(str_value.c_str()), "\0", 1);
+            memcpy((void*)(flash.flash_memory + offset), str_value.c_str(),
+                   strlen(str_value.c_str()));
+            memcpy((void*)(flash.flash_memory + offset + strlen(str_value.c_str())), "\0", 1);
             *str_param_idx = *str_param_idx + 1;
         }
     }
 
-    if (*int_param_idx != num_int_params || *str_param_idx != num_str_params) {
-        std::cout << "YamlParameters:" <<
-        "Number of parameters in the file isn't equal to the one specified in the constructor\n";
+    if (*int_param_idx != params.num_int_params || *str_param_idx != params.num_str_params) {
+        logger.error("Number of parameters in the file isn't equal to",
+                     " the one specified in the constructor\n");
         return LIBPARAMS_WRONG_ARGS;
     }
     return LIBPARAMS_OK;
 }
 
 int8_t YamlParameters::__write_page(std::ofstream& params_storage_file, uint8_t* int_param_idx,
-                                                                    uint8_t* str_param_idx) {
-    if (*int_param_idx > num_int_params || *str_param_idx > num_str_params) {
-        std::cout<<
-        "YamlParameters: int_param_idx or str_param_idx is bigger than defined by num_int_params\n";
+                                    uint8_t* str_param_idx) {
+    if (*int_param_idx > params.num_int_params || *str_param_idx > params.num_str_params) {
+        logger.error("int_param_idx or str_param_idx is bigger than defined by num_int_params\n");
         return LIBPARAMS_WRONG_ARGS;
     }
+
     uint32_t n_bytes = 0;
     uint8_t param_idx = *int_param_idx;
-    for (uint8_t index = param_idx; index < num_int_params; index++) {
+    for (uint8_t index = param_idx; index < params.num_int_params; index++) {
+        std::stringstream buffer;
         int32_t int_param_value;
-        memcpy(&int_param_value, flash_memory + index * 4, 4);
-        const char* name = integer_desc_pool[index].name;
+        memcpy(&int_param_value, flash.flash_memory + index * 4, 4);
+        const char* name = params.integer_desc_pool[index].name;
         params_storage_file << std::left << std::setw(32) << name << ": "
                             << int_param_value << "\n";
-        std::cout << std::left << std::setw(32) << name << ":\t" << int_param_value << "\n";
+        logger.info(std::left, std::setw(32), name, ":\t", int_param_value, "\n");
         n_bytes += 4;
         *int_param_idx = *int_param_idx + 1;
-        if (n_bytes + 4 > page_size) {
+        if (n_bytes + 4 > flash.page_size) {
             return LIBPARAMS_OK;
         }
     }
 
     auto prev_str_idx = *str_param_idx;
-    auto last_str_param_idx = num_str_params;
-    auto str_params_remained = num_str_params - prev_str_idx;
-    int available_str_params = (page_size - n_bytes) / 56;
+    auto last_str_param_idx = params.num_str_params;
+    auto str_params_remained = params.num_str_params - prev_str_idx;
+    int available_str_params = (flash.page_size - n_bytes) / 56;
 
     if (available_str_params < str_params_remained) {
         last_str_param_idx = prev_str_idx + available_str_params;
     }
     for (uint8_t index = prev_str_idx; index < last_str_param_idx; index++) {
-        size_t offset = flash_pages_num * page_size - MAX_STRING_LENGTH * (num_str_params - index);
+        std::stringstream buffer;
+        size_t offset = flash.flash_pages_num * flash.page_size -
+                        MAX_STRING_LENGTH * (params.num_str_params - index);
 
-        std::string str_param_value(
-            reinterpret_cast<char*>(flash_memory + offset), MAX_STRING_LENGTH);
+        std::string str_param_value(reinterpret_cast<char*>((void*)flash.flash_memory + offset),
+                                    MAX_STRING_LENGTH);
         auto str_end = str_param_value.find('\0');
         auto str_param = str_param_value.substr(0, str_end);
-        const char* name = string_desc_pool[index].name;
+        const char* name = params.string_desc_pool[index].name;
 
         params_storage_file << std::left << std::setw(32) << name << ": " << '"'
-                                                            << str_param.c_str() << '"' << "\n";
-        std::cout << std::left << std::setw(32) << name << ":\t" << '"'
-                                                            << str_param.c_str() << '"' << "\n";
+                            << str_param.c_str() << '"' << "\n";
+        logger.info(std::left, std::setw(32), name, ":\t", '"', str_param.c_str(), '"', "\n");
 
         n_bytes += MAX_STRING_LENGTH;
 
         *str_param_idx = *str_param_idx + 1;
-        if (n_bytes + 56 > page_size) {
+        if (n_bytes + 56 > flash.page_size) {
             return LIBPARAMS_OK;
         }
     }

--- a/platform_specific/ubuntu/YamlParameters.hpp
+++ b/platform_specific/ubuntu/YamlParameters.hpp
@@ -10,36 +10,18 @@
 #define LIBPARAM_YAML_PARAMETERS_HPP_
 
 #include <string.h>
+#include "SimpleLogger.hpp"
+#include "FlashMemoryLayout.hpp"
 
+static SimpleLogger logger("YamlParameters");
 class YamlParameters {
-    uint8_t* flash_memory;
-    uint16_t page_size;
-    uint8_t flash_pages_num;
-    uint8_t num_str_params;
-    uint8_t num_int_params;
-    uint32_t flash_size;
+    FlashMemoryLayout_t flash;
+    ParametersLayout_t params;
     std::string init_file_name = "init_params";
     std::string temp_file_name = "temp_params";
 
-   public:
-    YamlParameters(uint8_t* flash_memory_ptr, uint16_t page_size_bytes, uint8_t num_flash_pages,
-                                                uint8_t str_params_num, uint8_t int_params_num)
-    : flash_memory(flash_memory_ptr), page_size(page_size_bytes), flash_pages_num(num_flash_pages),
-    num_str_params(str_params_num), num_int_params(int_params_num) {
-        if (flash_memory_ptr == nullptr || page_size_bytes < 4 || num_flash_pages == 0) {
-            throw std::invalid_argument("YamlParameters: Invalid arguments for constructor");
-        }
-        flash_size = page_size * flash_pages_num;
-        uint32_t req_flash_size = num_flash_pages * 4 + 56 * num_str_params;
-        if (flash_size < req_flash_size) {
-                char error_mesg[100];
-                snprintf(error_mesg, sizeof(error_mesg),
-                    "YamlParameters: Not enought flash size, needed: %d, provided: %d\n",
-                    (int)req_flash_size, (int)flash_size);
-                std::cout << error_mesg;
-                throw std::invalid_argument(error_mesg);
-        }
-    }
+public:
+    explicit YamlParameters(FlashMemoryLayout_t flash_desc, ParametersLayout_t params_desc);
 
     int8_t read_from_dir(const std::string& path);
     int8_t write_to_dir(const std::string& path);
@@ -49,9 +31,9 @@ class YamlParameters {
 
 private:
     int8_t __write_page(std::ofstream& params_storage_file, uint8_t* int_param_idx,
-                                                                    uint8_t* str_param_idx);
+                        uint8_t* str_param_idx);
     int8_t __read_page(std::ifstream& params_storage_file, uint8_t* int_param_idx,
-                                                                    uint8_t* str_param_idx);
+                       uint8_t* str_param_idx);
 };
 
 #endif  // LIBPARAM_YAML_PARAMETERS_HPP_

--- a/platform_specific/ubuntu/flash_driver.cpp
+++ b/platform_specific/ubuntu/flash_driver.cpp
@@ -26,9 +26,9 @@ extern IntegerDesc_t integer_desc_pool[];
 extern StringDesc_t string_desc_pool[];
 
 static const FlashMemoryLayout_t mem_layout = {
-    .flash_memory       = flash_memory,
+    .memory_ptr       = flash_memory,
     .page_size          = PAGE_SIZE_BYTES,
-    .flash_pages_num    = n_flash_pages,
+    .num_pages    = n_flash_pages,
 };
 
 static ParametersLayout_t params_layout = {

--- a/scripts/generate_default_params.py
+++ b/scripts/generate_default_params.py
@@ -57,8 +57,8 @@ class Generator:
         string_iter = iter(self.strings_array)
         num_pages = math.ceil((4 * len(self.integers_array) + 56 * len(self.strings_array)) 
                               / page_size)
-
         for page_idx in range(num_pages):
+            print(page_idx)
             yaml_content = ""
             with open(f"{self.dir}/{self.name}_{page_idx}.yaml", 'w', encoding="utf-8") as yaml_fd:
                 while array_size < page_size - 56:
@@ -74,9 +74,11 @@ class Generator:
                             array_size += 56
                         except:
                             yaml_fd.write(yaml_content)
+                            yaml_fd.close()
                             return
                 array_size = 0
-                if (yaml_fd.write(yaml_content) != 0):
+                if (yaml_fd.write(yaml_content) == 0):
+                    print("No way")
                     sys.exit(1)
                 yaml_fd.close()
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -27,30 +27,9 @@ include_directories(${GTEST_INCLUDE_DIR})
 set(LIBPARAMS_PLATFORM ubuntu)
 include(${ROOT_DIR}/CMakeLists.txt)
 
-function(generate_random_params)
-    set(LIBPARAMS_PARAMS_INIT_NAME init_params)
-    set(LIBPARAMS_PARAMS_TEMP_NAME temp_params)
-    add_definitions(-DLIBPARAMS_PARAMS_DIR="${CMAKE_CURRENT_BINARY_DIR}")
-    execute_process(
-        COMMAND ${ROOT_DIR}/scripts/generate_random_params.py 
-        --out-dir ${CMAKE_CURRENT_BINARY_DIR}
-        RESULT_VARIABLE ret
-    )
-    if(NOT ret EQUAL 0)
-        message( FATAL_ERROR "Random Params Generator has been failed. Abort.")
-    endif()
-    execute_process(
-        COMMAND ${ROOT_DIR}/scripts/generate_default_params.py --out-dir ${CMAKE_CURRENT_BINARY_DIR} -f ${CMAKE_CURRENT_BINARY_DIR}/params.cpp
-        --out-file-name ${LIBPARAMS_PARAMS_INIT_NAME}
-        RESULT_VARIABLE ret
-    )
-    if(NOT ret EQUAL 0)
-        message( FATAL_ERROR "Default Params Generator has been failed. Abort.")
-    endif()
-endfunction()
+add_definitions(-DLIBPARAMS_PARAMS_DIR="${TESTS_DIR}/params")
 
 function(gen_test app_name test_file)
-
     # Create the executable target
     add_executable(${app_name}
     ${test_file}
@@ -59,16 +38,9 @@ function(gen_test app_name test_file)
     target_include_directories(${app_name} PUBLIC ${libparamsHeaders})
 
     # Conditional source file based on app_name
-    if(${app_name} STREQUAL yaml_parameters)
-        message(STATUS "${app_name} params dir ${CMAKE_CURRENT_BINARY_DIR}")
-        generate_random_params()
-        target_sources(${app_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/params.cpp)
-        target_include_directories(${app_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-    else ()
-        message(STATUS "${app_name} params dir ${UNIT_TESTS_DIR}")
-        target_sources(${app_name} PRIVATE ${TESTS_DIR}/params/params.c)
-        target_include_directories(${app_name} PRIVATE ${TESTS_DIR}/params/)
-    endif()
+    message(STATUS "${app_name} params dir ${UNIT_TESTS_DIR}")
+    target_sources(${app_name} PRIVATE ${TESTS_DIR}/params/params.c)
+    target_include_directories(${app_name} PRIVATE ${TESTS_DIR}/params/)
 
     # Link libraries to the target
     target_link_libraries(${app_name} gtest)

--- a/tests/unit_tests/test_yaml_parameters.cpp
+++ b/tests/unit_tests/test_yaml_parameters.cpp
@@ -18,217 +18,319 @@
 #include "common/algorithms.hpp"
 #include "flash_driver.h"
 #include "libparams_error_codes.h"
-#include "params.hpp"
-#include "storage.h"
 
-// #define F_NAME_LEN strlen(LIBPARAMS_INITIAL_PARAMS_FILE) + 10
-// #define SIM_F_NAME_LEN strlen(LIBPARAMS_TEMP_PARAMS_FILE) + 10
-#define NUM_INT_PARAMS          IntParamsIndexes::INTEGER_PARAMS_AMOUNT
-#define NUM_STR_PARAMS          NUM_OF_STR_PARAMS
-#define REQ_FLASH_SIZE          NUM_INT_PARAMS * 4 + NUM_STR_PARAMS * 56
-extern IntegerDesc_t integer_desc_pool[];
-extern StringDesc_t string_desc_pool[];
+// #define NUM_INT_PARAMS          IntParamsIndexes::INTEGER_PARAMS_AMOUNT
+// #define NUM_STR_PARAMS          NUM_OF_STR_PARAMS
+// #define REQ_FLASH_SIZE          NUM_INT_PARAMS * 4 + NUM_STR_PARAMS * 56
+// extern IntegerDesc_t integer_desc_pool[];
+// extern StringDesc_t string_desc_pool[];
 std::string dir(LIBPARAMS_PARAMS_DIR);
 
-int8_t delete_file(const char* path) {
+int8_t delete_file_from_dir(const char* path) {
+    std::string full_path = dir;
+    full_path.append(path);
     try {
-        if (std::filesystem::remove(path)) {
-            std::cout << "file " << path << " deleted.\n";
+        if (std::filesystem::remove(full_path)) {
+            std::cout << "file " << full_path << " deleted.\n";
         } else {
-            std::cout << "file " << path << " not found.\n";
+            std::cout << "file " << full_path << " not found.\n";
             return -1;
         }
     } catch (const std::filesystem::filesystem_error& err) {
-        std::cout << "filesystem error: " << path << err.what() << '\n';
+        std::cout << "filesystem error: " << full_path << err.what() << '\n';
         return -1;
     }
     return 0;
 }
 
 
-// Test Case 1. Initialize YamlParameters
-TEST(TestYamlParameters, yaml_init_okay) {
-    uint8_t flash[100];
-    YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1, NUM_STR_PARAMS,
-                                                                        NUM_INT_PARAMS);
+class YamlParamsTest{
+public:
+    YamlParameters * yaml_params;
+    IntegerDesc_t* integer_desc_pool_ptr;
+    StringDesc_t* string_desc_pool_ptr;
+    void SetUp() {
+        FlashMemoryLayout_t flash = {};
+        ParametersLayout_t params = {
+            .integer_desc_pool = integer_desc_pool_ptr,
+            .string_desc_pool = string_desc_pool_ptr
+        };
+        yaml_params = new YamlParameters(flash, params);
+    }
+    void TearDown() {
+        delete yaml_params;
+    }
+};
+
+class YamlParamsStandardPoolTest : public ::testing::Test {
+protected:
+    IntegerDesc_t integer_desc_pool[512] = {
+        {"uavcan.node.id",        0,      127,     50,        MUTABLE},
+        {"uavcan.pub.mag.id",     0,      65535,   65535,     MUTABLE},
+        {"uavcan.can.baudrate",   100000, 8000000, 1000000,   IMMUTABLE},
+    };
+
+    StringDesc_t string_desc_pool[512] = {
+        {"name", "Unknown", MUTABLE},
+        {"uavcan.pub.mag.type", "uavcan.si.sample.magnetic_field_strength.Vector3", IMMUTABLE},
+    };
+    uint8_t flash_memory[124];
+    YamlParameters * yaml_params;
+    FlashMemoryLayout_t flash;
+    ParametersLayout_t params;
+    void SetUp() {
+        flash = {
+            .flash_memory = flash_memory,
+            .flash_pages_num = 1,
+            .flash_size = 124
+        };
+        params = {
+            .integer_desc_pool = integer_desc_pool,
+            .string_desc_pool = string_desc_pool,
+            .num_int_params = 3,
+            .num_str_params = 2
+        };
+        yaml_params = new YamlParameters(flash, params);
+    }
+};
+
+TEST_F(YamlParamsStandardPoolTest, FileNamesConsistency) {
+    ASSERT_NE(yaml_params, nullptr);
+
+    ASSERT_EQ(yaml_params->set_temp_file_name(""), LIBPARAMS_WRONG_ARGS);
+    ASSERT_EQ(yaml_params->set_init_file_name(""), LIBPARAMS_WRONG_ARGS);
+
+    ASSERT_EQ(yaml_params->set_init_file_name("file1"), LIBPARAMS_OK);
+    ASSERT_EQ(yaml_params->set_temp_file_name("file2"), LIBPARAMS_OK);
+
+    delete_file_from_dir("file1");
+    delete_file_from_dir("file2");
+
+    ASSERT_FALSE(std::filesystem::exists(dir + "file1"));
+    ASSERT_FALSE(std::filesystem::exists(dir + "file2"));
+    ASSERT_EQ(yaml_params->read_from_dir(dir), LIBPARAMS_WRONG_ARGS);
+
+    ASSERT_EQ(yaml_params->write_to_dir(dir), LIBPARAMS_OK);
+    ASSERT_FALSE(std::filesystem::exists(dir + "file1"));
+    ASSERT_TRUE(std::filesystem::exists(dir + "file2"));
+
+    ASSERT_EQ(yaml_params->read_from_dir(dir), LIBPARAMS_OK);
+    ASSERT_EQ(delete_file_from_dir("file2"), 0);
 }
 
-// Test Case 1. Initialize YamlParameters
-TEST(TestYamlParameters, yaml_init_okay_2_pages) {
-    uint8_t flash[100];
-    YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE/2, 2, NUM_STR_PARAMS,
-                                                                        NUM_INT_PARAMS);
-}
+TEST_F(YamlParamsStandardPoolTest, ComparePool) {
+    ASSERT_NE(yaml_params, nullptr);
 
-TEST(TestYamlParameters, flash_null_ptr) {
-    uint8_t* flash = 0;
-    EXPECT_THROW(YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 0),
-                                                            std::invalid_argument);
-}
-
-TEST(TestYamlParameters, zero_page_size) {
-    uint8_t flash[100];
-    EXPECT_THROW(YamlParameters yaml_params = YamlParameters(flash, 0, 1, 0, 0),
-                                                            std::invalid_argument);
-}
-
-TEST(TestYamlParameters, page_n_zero) {
-    uint8_t flash[100];
-    EXPECT_THROW(YamlParameters yaml_params = YamlParameters(flash, 100, 0, 0, 0),
-                                                            std::invalid_argument);
-}
-
-TEST(TestYamlParameters, not_enought_page_size) {
-    uint8_t flash[REQ_FLASH_SIZE];
-    EXPECT_THROW(YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE - 100, 1,
-                        NUM_OF_STR_PARAMS, NUM_STR_PARAMS), std::invalid_argument);
-}
-
-// Case 2. Set empty file names
-TEST(TestYamlParameters, set_file_names_ok) {
-    uint8_t flash[100];
-    YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 0);
-    auto res = yaml_params.set_init_file_name("random");
-    ASSERT_EQ(res, LIBPARAMS_OK);
-    res = yaml_params.set_temp_file_name("random");
-    ASSERT_EQ(res, LIBPARAMS_OK);
-}
-
-TEST(TestYamlParameters, set_empty_init_file_name) {
-    uint8_t flash[100];
-    YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 0);
-    auto res = yaml_params.set_init_file_name("");
-    ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
-}
-
-TEST(TestYamlParameters, set_empty_temp_file_name) {
-    uint8_t flash[100];
-    YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 0);
-    auto res = yaml_params.set_temp_file_name("");
-    ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
-}
-
-
-// Case 3. Write to file
-TEST(TestYamlParameters, write_ok) {
-    uint8_t flash[REQ_FLASH_SIZE];
-    YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
-                                                                NUM_STR_PARAMS, NUM_INT_PARAMS);
-    auto res = yaml_params.write_to_dir(dir);
-    delete_file((dir + "/temp_params_0.yaml").c_str());
-    ASSERT_EQ(res, LIBPARAMS_OK);
-}
-
-TEST(TestYamlParameters, write_empty_path) {
-    uint8_t flash[100];
-    YamlParameters yaml_params = YamlParameters(flash, 100, 1, 1, 1);
-    auto res = yaml_params.write_to_dir("");
-    ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
-}
-
-TEST(TestYamlParameters, write_wrong_params_num) {
-    uint8_t flash[200];
-    YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 1);
-    auto res = yaml_params.write_to_dir(dir);
-
-    delete_file((dir + "/temp_params_0.yaml").c_str());
-}
-
-
-// Test Case 4 Read from file
-TEST(TestYamlParameters, read_ok) {
-    uint8_t flash[REQ_FLASH_SIZE];
-
-    YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
-                                                            NUM_STR_PARAMS, NUM_INT_PARAMS);
-    auto res = yaml_params.read_from_dir(dir);
-    ASSERT_EQ(res, LIBPARAMS_OK);
-}
-
-TEST(TestYamlParameters, read_no_such_file) {
-    uint8_t flash[100];
-    char file_name[10];
-    generateRandomCString(file_name, 10);
-    YamlParameters yaml_params = YamlParameters(flash, 100, 1, 1, 1);
-    yaml_params.set_init_file_name(file_name);
-    auto res = yaml_params.read_from_dir(dir);
-    ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
-}
-
-
-TEST(TestYamlParameters, read_empty_file) {
-    uint8_t flash[REQ_FLASH_SIZE];
-    char file_name[10];
-    generateRandomCString(file_name, 10);
-    std::ofstream params_storage_file;
-    std::string file_path = dir;
-    file_path.append("/").append(file_name) + ".yaml";
-    params_storage_file.open(file_path, std::ios_base::out);
-    YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
-                                                            NUM_STR_PARAMS, NUM_INT_PARAMS);
-    yaml_params.set_init_file_name(file_name);
-    auto res = yaml_params.read_from_dir(dir);
-    delete_file(file_path.c_str());
-    ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
-}
-
-
-// Test Case 5. Check if reading is right compare to the generated params
-// description params.cpp file.
-TEST(TestYamlParameters, read_comparison) {
-    uint8_t flash[REQ_FLASH_SIZE];
-
-    YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
-                                                        NUM_STR_PARAMS, NUM_INT_PARAMS);
-    auto res = yaml_params.read_from_dir(dir);
-    ASSERT_EQ(res, LIBPARAMS_OK);
-    for (uint8_t idx = 0; idx < IntParamsIndexes::INTEGER_PARAMS_AMOUNT; idx ++) {
+    ASSERT_EQ(yaml_params->write_to_dir(dir), LIBPARAMS_OK);
+    ASSERT_TRUE(std::filesystem::exists(dir + "file2"));
+    for (uint8_t idx = 0; idx < params.num_int_params; idx ++) {
         int32_t int_val = 0;
-        memcpy(&int_val, flash + 4 * idx, 4);
+        memcpy(&int_val, flash_memory + 4 * idx, 4);
         ASSERT_EQ(int_val, integer_desc_pool[idx].def);
     }
-    for (uint8_t idx = 0; idx < NUM_OF_STR_PARAMS; idx ++) {
-        auto offset = REQ_FLASH_SIZE - MAX_STRING_LENGTH * (NUM_OF_STR_PARAMS - idx);
-        std::string str_val(reinterpret_cast<char*>(flash + offset),
+    for (uint8_t idx = 0; idx < params.num_str_params; idx ++) {
+        auto offset = flash.flash_size - MAX_STRING_LENGTH * (params.num_int_params - idx);
+        std::string str_val(reinterpret_cast<char*>(flash_memory + offset),
         MAX_STRING_LENGTH);
         auto def = (char*)(string_desc_pool[idx].def);
         ASSERT_STREQ(str_val.c_str(), def);
     }
 }
 
+// TEST_F(YamlParamsStandardPoolTest, Base) {
+//     res = yaml_params.write_to_dir(dir);
+//     yaml_params->write_to_dir();
+// }
+// // Test Case 1. Initialize YamlParameters
+// TEST(TestYamlParameters, yaml_init_okay) {
+//     FlashMemoryLayout_t flash = {
+//         .flash_memory = {},
+//         .flash_size = 100
+//     };
+//     ParametersLayout_t params = {
+//         .integer_desc_pool = 
+//     }
+//     ParametersLayout_t params = {};
+//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1, NUM_STR_PARAMS,
+//                                                                         NUM_INT_PARAMS);
+// }
 
-// Test Case 6. Check if created file is the same as initial_params yaml file generated
-// by python script (/scripts/generate_random_params.py).
-TEST(TestYamlParameters, write_comparison) {
-    uint8_t flash[REQ_FLASH_SIZE];
+// // Test Case 1. Initialize YamlParameters
+// TEST(TestYamlParameters, yaml_init_okay_2_pages) {
+//     uint8_t flash[100];
+//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE/2, 2, NUM_STR_PARAMS,
+//                                                                         NUM_INT_PARAMS);
+// }
 
-    YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
-                                                        NUM_STR_PARAMS, NUM_INT_PARAMS);
-    auto res = yaml_params.read_from_dir(dir);
-    ASSERT_EQ(res, LIBPARAMS_OK);
-    yaml_params.set_temp_file_name("written");
-    res = yaml_params.write_to_dir(dir);
-    ASSERT_EQ(res, LIBPARAMS_OK);
+// TEST(TestYamlParameters, flash_null_ptr) {
+//     uint8_t* flash = 0;
+//     EXPECT_THROW(YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 0),
+//                                                             std::invalid_argument);
+// }
 
-    auto file_name = dir + "/" + "init_params_0.yaml";
-    std::ifstream init_storage_file;
-    init_storage_file.open(file_name, std::ios_base::in);
+// TEST(TestYamlParameters, zero_page_size) {
+//     uint8_t flash[100];
+//     EXPECT_THROW(YamlParameters yaml_params = YamlParameters(flash, 0, 1, 0, 0),
+//                                                             std::invalid_argument);
+// }
 
-    file_name = dir + "/" + "written_0.yaml";
-    std::ifstream written_storage_file;
-    written_storage_file.open(file_name, std::ios_base::in);
+// TEST(TestYamlParameters, page_n_zero) {
+//     uint8_t flash[100];
+//     EXPECT_THROW(YamlParameters yaml_params = YamlParameters(flash, 100, 0, 0, 0),
+//                                                             std::invalid_argument);
+// }
+
+// TEST(TestYamlParameters, not_enought_page_size) {
+//     uint8_t flash[REQ_FLASH_SIZE];
+//     EXPECT_THROW(YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE - 100, 1,
+//                         NUM_OF_STR_PARAMS, NUM_STR_PARAMS), std::invalid_argument);
+// }
+
+// // Case 2. Set empty file names
+// TEST(TestYamlParameters, set_file_names_ok) {
+//     uint8_t flash[100];
+//     YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 0);
+//     auto res = yaml_params.set_init_file_name("random");
+//     ASSERT_EQ(res, LIBPARAMS_OK);
+//     res = yaml_params.set_temp_file_name("random");
+//     ASSERT_EQ(res, LIBPARAMS_OK);
+// }
+
+// TEST(TestYamlParameters, set_empty_init_file_name) {
+//     uint8_t flash[100];
+//     YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 0);
+//     auto res = yaml_params.set_init_file_name("");
+//     ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
+// }
+
+// TEST(TestYamlParameters, set_empty_temp_file_name) {
+//     uint8_t flash[100];
+//     YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 0);
+//     auto res = yaml_params.set_temp_file_name("");
+//     ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
+// }
 
 
-    std::string line;
-    std::string written_line;
-    while (std::getline(init_storage_file, line)) {
-        std::getline(written_storage_file, written_line);
-        ASSERT_STREQ(line.c_str(), written_line.c_str());
-    }
-    init_storage_file.close();
-    written_storage_file.close();
-    delete_file(file_name.c_str());
-}
+// // Case 3. Write to file
+// TEST(TestYamlParameters, write_ok) {
+//     uint8_t flash[REQ_FLASH_SIZE];
+//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
+//                                                                 NUM_STR_PARAMS, NUM_INT_PARAMS);
+//     auto res = yaml_params.write_to_dir(dir);
+//     delete_file((dir + "/temp_params_0.yaml").c_str());
+//     ASSERT_EQ(res, LIBPARAMS_OK);
+// }
+
+// TEST(TestYamlParameters, write_empty_path) {
+//     uint8_t flash[100];
+//     YamlParameters yaml_params = YamlParameters(flash, 100, 1, 1, 1);
+//     auto res = yaml_params.write_to_dir("");
+//     ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
+// }
+
+// TEST(TestYamlParameters, write_wrong_params_num) {
+//     uint8_t flash[200];
+//     YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 1);
+//     auto res = yaml_params.write_to_dir(dir);
+
+//     delete_file((dir + "/temp_params_0.yaml").c_str());
+// }
+
+
+// // Test Case 4 Read from file
+// TEST(TestYamlParameters, read_ok) {
+//     uint8_t flash[REQ_FLASH_SIZE];
+
+//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
+//                                                             NUM_STR_PARAMS, NUM_INT_PARAMS);
+//     auto res = yaml_params.read_from_dir(dir);
+//     ASSERT_EQ(res, LIBPARAMS_OK);
+// }
+
+// TEST(TestYamlParameters, read_no_such_file) {
+//     uint8_t flash[100];
+//     char file_name[10];
+//     generateRandomCString(file_name, 10);
+//     YamlParameters yaml_params = YamlParameters(flash, 100, 1, 1, 1);
+//     yaml_params.set_init_file_name(file_name);
+//     auto res = yaml_params.read_from_dir(dir);
+//     ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
+// }
+
+
+// TEST(TestYamlParameters, read_empty_file) {
+//     uint8_t flash[REQ_FLASH_SIZE];
+//     char file_name[10];
+//     generateRandomCString(file_name, 10);
+//     std::ofstream params_storage_file;
+//     std::string file_path = dir;
+//     file_path.append("/").append(file_name) + ".yaml";
+//     params_storage_file.open(file_path, std::ios_base::out);
+//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
+//                                                             NUM_STR_PARAMS, NUM_INT_PARAMS);
+//     yaml_params.set_init_file_name(file_name);
+//     auto res = yaml_params.read_from_dir(dir);
+//     delete_file(file_path.c_str());
+//     ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
+// }
+
+
+// // Test Case 5. Check if reading is right compare to the generated params
+// // description params.cpp file.
+// TEST(TestYamlParameters, read_comparison) {
+//     uint8_t flash[REQ_FLASH_SIZE];
+
+//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
+//                                                         NUM_STR_PARAMS, NUM_INT_PARAMS);
+//     auto res = yaml_params.read_from_dir(dir);
+//     ASSERT_EQ(res, LIBPARAMS_OK);
+//     for (uint8_t idx = 0; idx < IntParamsIndexes::INTEGER_PARAMS_AMOUNT; idx ++) {
+//         int32_t int_val = 0;
+//         memcpy(&int_val, flash + 4 * idx, 4);
+//         ASSERT_EQ(int_val, integer_desc_pool[idx].def);
+//     }
+//     for (uint8_t idx = 0; idx < NUM_OF_STR_PARAMS; idx ++) {
+//         auto offset = REQ_FLASH_SIZE - MAX_STRING_LENGTH * (NUM_OF_STR_PARAMS - idx);
+//         std::string str_val(reinterpret_cast<char*>(flash + offset),
+//         MAX_STRING_LENGTH);
+//         auto def = (char*)(string_desc_pool[idx].def);
+//         ASSERT_STREQ(str_val.c_str(), def);
+//     }
+// }
+
+
+// // Test Case 6. Check if created file is the same as initial_params yaml file generated
+// // by python script (/scripts/generate_random_params.py).
+// TEST(TestYamlParameters, write_comparison) {
+//     uint8_t flash[REQ_FLASH_SIZE];
+
+//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
+//                                                         NUM_STR_PARAMS, NUM_INT_PARAMS);
+//     auto res = yaml_params.read_from_dir(dir);
+//     ASSERT_EQ(res, LIBPARAMS_OK);
+//     yaml_params.set_temp_file_name("written");
+//     res = yaml_params.write_to_dir(dir);
+//     ASSERT_EQ(res, LIBPARAMS_OK);
+
+//     auto file_name = dir + "/" + "init_params_0.yaml";
+//     std::ifstream init_storage_file;
+//     init_storage_file.open(file_name, std::ios_base::in);
+
+//     file_name = dir + "/" + "written_0.yaml";
+//     std::ifstream written_storage_file;
+//     written_storage_file.open(file_name, std::ios_base::in);
+
+
+//     std::string line;
+//     std::string written_line;
+//     while (std::getline(init_storage_file, line)) {
+//         std::getline(written_storage_file, written_line);
+//         ASSERT_STREQ(line.c_str(), written_line.c_str());
+//     }
+//     init_storage_file.close();
+//     written_storage_file.close();
+//     delete_file(file_name.c_str());
+// }
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);

--- a/tests/unit_tests/test_yaml_parameters.cpp
+++ b/tests/unit_tests/test_yaml_parameters.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <experimental/random>
 
 #include <algorithm>
 #include <filesystem>
@@ -17,18 +18,13 @@
 #include "YamlParameters.hpp"
 #include "common/algorithms.hpp"
 #include "flash_driver.h"
-#include "libparams_error_codes.h"
 
-// #define NUM_INT_PARAMS          IntParamsIndexes::INTEGER_PARAMS_AMOUNT
-// #define NUM_STR_PARAMS          NUM_OF_STR_PARAMS
-// #define REQ_FLASH_SIZE          NUM_INT_PARAMS * 4 + NUM_STR_PARAMS * 56
-// extern IntegerDesc_t integer_desc_pool[];
-// extern StringDesc_t string_desc_pool[];
 std::string dir(LIBPARAMS_PARAMS_DIR);
+uint8_t flash_memory[100];
 
 int8_t delete_file_from_dir(const char* path) {
     std::string full_path = dir;
-    full_path.append(path);
+    full_path.append("/").append(path);
     try {
         if (std::filesystem::remove(full_path)) {
             std::cout << "file " << full_path << " deleted.\n";
@@ -44,25 +40,127 @@ int8_t delete_file_from_dir(const char* path) {
 }
 
 
-class YamlParamsTest{
+class YamlParamsTestBase : public ::testing::Test{
 public:
     YamlParameters * yaml_params;
-    IntegerDesc_t* integer_desc_pool_ptr;
-    StringDesc_t* string_desc_pool_ptr;
-    void SetUp() {
-        FlashMemoryLayout_t flash = {};
-        ParametersLayout_t params = {
-            .integer_desc_pool = integer_desc_pool_ptr,
-            .string_desc_pool = string_desc_pool_ptr
-        };
-        yaml_params = new YamlParameters(flash, params);
+    FlashMemoryLayout_t flash;
+    ParametersLayout_t params;
+
+    void generate_params_pools() {
+        IntegerDesc_t integer_desc_pool[512];
+        StringDesc_t string_desc_pool[512];
+        char int_names[params.num_int_params][10];
+        char str_names[params.num_str_params][10];
+        params.integer_desc_pool = {};
+        for (int i = 0; i < params.num_int_params; i++) {
+            generateRandomCString(int_names[i], 10);
+            integer_desc_pool[i].name = int_names[i];
+            integer_desc_pool[i].def = std::experimental::randint(0, 10000);
+        }
+        for (int i = 0; i < params.num_str_params; i++) {
+            generateRandomCString(str_names[i], 10);
+            string_desc_pool[i].name = str_names[i];
+            *string_desc_pool[i].def = *(uint8_t*)str_names[i];
+        }
+        params.integer_desc_pool = integer_desc_pool;
+        params.string_desc_pool = string_desc_pool;
     }
-    void TearDown() {
-        delete yaml_params;
+
+    void compare_flash_with_pool(){
+        for (uint8_t idx = 0; idx < params.num_int_params; idx ++) {
+            int32_t int_val = 0;
+            memcpy(&int_val, flash.memory_ptr + 4 * idx, 4);
+            ASSERT_EQ(int_val, params.integer_desc_pool[idx].def);
+        }
+        for (uint8_t idx = 0; idx < params.num_str_params; idx ++) {
+            auto offset = flash.flash_size - MAX_STRING_LENGTH * (params.num_str_params - idx);
+            std::string str_val((char*)(flash.memory_ptr + offset), MAX_STRING_LENGTH);
+            auto def = (char*)(params.string_desc_pool[idx].def);
+            ASSERT_STREQ(str_val.c_str(), def);
+        }
     }
+    int8_t fill_flash_with_default() {
+    for (int i = 0; i < params.num_int_params; i++) {
+        memcpy((void*)(flash.memory_ptr + 4 * i), &params.integer_desc_pool[i].def, 4);
+    }
+    for (int i = 0; i < params.num_str_params; i++) {
+        auto str_value = (char*)params.string_desc_pool[i].def;
+        int offset = flash.num_pages * flash.page_size - MAX_STRING_LENGTH *
+                         (params.num_str_params - i);
+        memcpy((void*)(flash.memory_ptr + offset), str_value, strlen(str_value));
+    }
+    return 0;
+}
 };
 
-class YamlParamsStandardPoolTest : public ::testing::Test {
+// Case 1. Check YamlParameters initialization with different parameters tuples
+
+struct InitParameters {
+    uint8_t* flash_ptr;
+    int num_pages;
+    int page_size;
+    int num_int_params;
+    int num_str_parms;
+    bool expected;
+};
+
+class YamlParametersParametrizedInitialization : public YamlParamsTestBase, public
+                ::testing::WithParamInterface<InitParameters> {};
+
+TEST_P(YamlParametersParametrizedInitialization, CheckYamlInitialization) {
+    auto parameters = GetParam();
+    flash.memory_ptr = parameters.flash_ptr;
+    flash.num_pages = parameters.num_pages;
+    flash.page_size = parameters.page_size;
+    flash.flash_size = flash.num_pages * flash.page_size;
+
+    params.num_int_params = parameters.num_int_params;
+    params.num_str_params = parameters.num_str_parms;
+    bool expected = parameters.expected;
+    generate_params_pools();
+    if (expected) {
+        YamlParameters(flash, params);  // Assuming constructor does not throw
+    } else {
+        EXPECT_THROW(yaml_params = new YamlParameters(flash, params),
+                                                            std::invalid_argument);
+    }
+}
+
+// Flash nullptr
+INSTANTIATE_TEST_CASE_P(
+        YamlParametersInitFlashPtrTests,
+        YamlParametersParametrizedInitialization,
+        ::testing::Values(
+                (InitParameters){flash_memory,   1,  100,    1,  1,  true},
+                (InitParameters){nullptr,        1,  100,    1,  1, false}));
+
+// Flash number of pages
+INSTANTIATE_TEST_CASE_P(
+        YamlParametersInitNumPagesTests,
+        YamlParametersParametrizedInitialization,
+        ::testing::Values(
+                // Total flash size equals to required for params num
+                (InitParameters){flash_memory,   1,  100,    1,  1,  true},
+                (InitParameters){flash_memory,  25,    4,   25,  0,  true},
+                // Page size equals to required for params num, but n pages = 0
+                (InitParameters){flash_memory,   0,  100,    1,  1, false}));
+
+INSTANTIATE_TEST_CASE_P(
+        YamlParametersInitPageSizeTests,
+        YamlParametersParametrizedInitialization,
+        ::testing::Values(
+                // Total flash size equals to required to store params
+                (InitParameters){flash_memory,   1,  112,    0,  2,  true},
+                (InitParameters){flash_memory,   1,  100,   25,  0,  true},
+                // Total flash size smaller than required to store params
+                (InitParameters){flash_memory,   1,  99,    25,  0,  false},
+                (InitParameters){flash_memory,   1,  55,     0,  1,  false},
+                // Page size smaller than int params size (4 bytes), total flash size is ok
+                (InitParameters){flash_memory,   4,    1,    1,  0,  false},
+                (InitParameters){flash_memory,   30,   3,    1,  1,  false}));
+
+
+class YamlParamsStandardPoolTest : public YamlParamsTestBase {
 protected:
     IntegerDesc_t integer_desc_pool[512] = {
         {"uavcan.node.id",        0,      127,     50,        MUTABLE},
@@ -75,14 +173,11 @@ protected:
         {"uavcan.pub.mag.type", "uavcan.si.sample.magnetic_field_strength.Vector3", IMMUTABLE},
     };
     uint8_t flash_memory[124];
-    YamlParameters * yaml_params;
-    FlashMemoryLayout_t flash;
-    ParametersLayout_t params;
     void SetUp() {
         flash = {
-            .flash_memory = flash_memory,
-            .flash_pages_num = 1,
-            .flash_size = 124
+            .memory_ptr = flash_memory,
+            .page_size = 124,
+            .num_pages = 1,
         };
         params = {
             .integer_desc_pool = integer_desc_pool,
@@ -95,242 +190,44 @@ protected:
 };
 
 TEST_F(YamlParamsStandardPoolTest, FileNamesConsistency) {
-    ASSERT_NE(yaml_params, nullptr);
-
     ASSERT_EQ(yaml_params->set_temp_file_name(""), LIBPARAMS_WRONG_ARGS);
     ASSERT_EQ(yaml_params->set_init_file_name(""), LIBPARAMS_WRONG_ARGS);
 
     ASSERT_EQ(yaml_params->set_init_file_name("file1"), LIBPARAMS_OK);
     ASSERT_EQ(yaml_params->set_temp_file_name("file2"), LIBPARAMS_OK);
 
-    delete_file_from_dir("file1");
-    delete_file_from_dir("file2");
+    delete_file_from_dir("file1_0.yaml");
+    delete_file_from_dir("file2_0.yaml");
 
-    ASSERT_FALSE(std::filesystem::exists(dir + "file1"));
-    ASSERT_FALSE(std::filesystem::exists(dir + "file2"));
+    // Reading non-existent files
+    ASSERT_FALSE(std::filesystem::exists(dir + "/file1_0.yaml"));
+    ASSERT_FALSE(std::filesystem::exists(dir + "/file2_0.yaml"));
     ASSERT_EQ(yaml_params->read_from_dir(dir), LIBPARAMS_WRONG_ARGS);
 
+    // Creation of file "/file1_0.yaml"
     ASSERT_EQ(yaml_params->write_to_dir(dir), LIBPARAMS_OK);
-    ASSERT_FALSE(std::filesystem::exists(dir + "file1"));
-    ASSERT_TRUE(std::filesystem::exists(dir + "file2"));
+    ASSERT_FALSE(std::filesystem::exists(dir + "/file1_0.yaml"));
+    ASSERT_TRUE(std::filesystem::exists(dir + "/file2_0.yaml"));
 
+    // Reading file "/file1_0.yaml"
     ASSERT_EQ(yaml_params->read_from_dir(dir), LIBPARAMS_OK);
-    ASSERT_EQ(delete_file_from_dir("file2"), 0);
+    ASSERT_EQ(delete_file_from_dir("file2_0.yaml"), 0);
 }
 
 TEST_F(YamlParamsStandardPoolTest, ComparePool) {
-    ASSERT_NE(yaml_params, nullptr);
-
+    // writing temp file with default values of pools entries
+    fill_flash_with_default();
+    compare_flash_with_pool();
     ASSERT_EQ(yaml_params->write_to_dir(dir), LIBPARAMS_OK);
-    ASSERT_TRUE(std::filesystem::exists(dir + "file2"));
-    for (uint8_t idx = 0; idx < params.num_int_params; idx ++) {
-        int32_t int_val = 0;
-        memcpy(&int_val, flash_memory + 4 * idx, 4);
-        ASSERT_EQ(int_val, integer_desc_pool[idx].def);
-    }
-    for (uint8_t idx = 0; idx < params.num_str_params; idx ++) {
-        auto offset = flash.flash_size - MAX_STRING_LENGTH * (params.num_int_params - idx);
-        std::string str_val(reinterpret_cast<char*>(flash_memory + offset),
-        MAX_STRING_LENGTH);
-        auto def = (char*)(string_desc_pool[idx].def);
-        ASSERT_STREQ(str_val.c_str(), def);
-    }
+    ASSERT_TRUE(std::filesystem::exists(dir + "/temp_params_0.yaml"));
+
+    // reading the values from the file into flash
+    ASSERT_EQ(yaml_params->set_init_file_name("temp_params"), LIBPARAMS_OK);
+    ASSERT_EQ(yaml_params->read_from_dir(dir), LIBPARAMS_OK);
+
+    compare_flash_with_pool();
+    delete_file_from_dir("temp_params_0.yaml");
 }
-
-// TEST_F(YamlParamsStandardPoolTest, Base) {
-//     res = yaml_params.write_to_dir(dir);
-//     yaml_params->write_to_dir();
-// }
-// // Test Case 1. Initialize YamlParameters
-// TEST(TestYamlParameters, yaml_init_okay) {
-//     FlashMemoryLayout_t flash = {
-//         .flash_memory = {},
-//         .flash_size = 100
-//     };
-//     ParametersLayout_t params = {
-//         .integer_desc_pool = 
-//     }
-//     ParametersLayout_t params = {};
-//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1, NUM_STR_PARAMS,
-//                                                                         NUM_INT_PARAMS);
-// }
-
-// // Test Case 1. Initialize YamlParameters
-// TEST(TestYamlParameters, yaml_init_okay_2_pages) {
-//     uint8_t flash[100];
-//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE/2, 2, NUM_STR_PARAMS,
-//                                                                         NUM_INT_PARAMS);
-// }
-
-// TEST(TestYamlParameters, flash_null_ptr) {
-//     uint8_t* flash = 0;
-//     EXPECT_THROW(YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 0),
-//                                                             std::invalid_argument);
-// }
-
-// TEST(TestYamlParameters, zero_page_size) {
-//     uint8_t flash[100];
-//     EXPECT_THROW(YamlParameters yaml_params = YamlParameters(flash, 0, 1, 0, 0),
-//                                                             std::invalid_argument);
-// }
-
-// TEST(TestYamlParameters, page_n_zero) {
-//     uint8_t flash[100];
-//     EXPECT_THROW(YamlParameters yaml_params = YamlParameters(flash, 100, 0, 0, 0),
-//                                                             std::invalid_argument);
-// }
-
-// TEST(TestYamlParameters, not_enought_page_size) {
-//     uint8_t flash[REQ_FLASH_SIZE];
-//     EXPECT_THROW(YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE - 100, 1,
-//                         NUM_OF_STR_PARAMS, NUM_STR_PARAMS), std::invalid_argument);
-// }
-
-// // Case 2. Set empty file names
-// TEST(TestYamlParameters, set_file_names_ok) {
-//     uint8_t flash[100];
-//     YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 0);
-//     auto res = yaml_params.set_init_file_name("random");
-//     ASSERT_EQ(res, LIBPARAMS_OK);
-//     res = yaml_params.set_temp_file_name("random");
-//     ASSERT_EQ(res, LIBPARAMS_OK);
-// }
-
-// TEST(TestYamlParameters, set_empty_init_file_name) {
-//     uint8_t flash[100];
-//     YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 0);
-//     auto res = yaml_params.set_init_file_name("");
-//     ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
-// }
-
-// TEST(TestYamlParameters, set_empty_temp_file_name) {
-//     uint8_t flash[100];
-//     YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 0);
-//     auto res = yaml_params.set_temp_file_name("");
-//     ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
-// }
-
-
-// // Case 3. Write to file
-// TEST(TestYamlParameters, write_ok) {
-//     uint8_t flash[REQ_FLASH_SIZE];
-//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
-//                                                                 NUM_STR_PARAMS, NUM_INT_PARAMS);
-//     auto res = yaml_params.write_to_dir(dir);
-//     delete_file((dir + "/temp_params_0.yaml").c_str());
-//     ASSERT_EQ(res, LIBPARAMS_OK);
-// }
-
-// TEST(TestYamlParameters, write_empty_path) {
-//     uint8_t flash[100];
-//     YamlParameters yaml_params = YamlParameters(flash, 100, 1, 1, 1);
-//     auto res = yaml_params.write_to_dir("");
-//     ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
-// }
-
-// TEST(TestYamlParameters, write_wrong_params_num) {
-//     uint8_t flash[200];
-//     YamlParameters yaml_params = YamlParameters(flash, 100, 1, 0, 1);
-//     auto res = yaml_params.write_to_dir(dir);
-
-//     delete_file((dir + "/temp_params_0.yaml").c_str());
-// }
-
-
-// // Test Case 4 Read from file
-// TEST(TestYamlParameters, read_ok) {
-//     uint8_t flash[REQ_FLASH_SIZE];
-
-//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
-//                                                             NUM_STR_PARAMS, NUM_INT_PARAMS);
-//     auto res = yaml_params.read_from_dir(dir);
-//     ASSERT_EQ(res, LIBPARAMS_OK);
-// }
-
-// TEST(TestYamlParameters, read_no_such_file) {
-//     uint8_t flash[100];
-//     char file_name[10];
-//     generateRandomCString(file_name, 10);
-//     YamlParameters yaml_params = YamlParameters(flash, 100, 1, 1, 1);
-//     yaml_params.set_init_file_name(file_name);
-//     auto res = yaml_params.read_from_dir(dir);
-//     ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
-// }
-
-
-// TEST(TestYamlParameters, read_empty_file) {
-//     uint8_t flash[REQ_FLASH_SIZE];
-//     char file_name[10];
-//     generateRandomCString(file_name, 10);
-//     std::ofstream params_storage_file;
-//     std::string file_path = dir;
-//     file_path.append("/").append(file_name) + ".yaml";
-//     params_storage_file.open(file_path, std::ios_base::out);
-//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
-//                                                             NUM_STR_PARAMS, NUM_INT_PARAMS);
-//     yaml_params.set_init_file_name(file_name);
-//     auto res = yaml_params.read_from_dir(dir);
-//     delete_file(file_path.c_str());
-//     ASSERT_EQ(res, LIBPARAMS_WRONG_ARGS);
-// }
-
-
-// // Test Case 5. Check if reading is right compare to the generated params
-// // description params.cpp file.
-// TEST(TestYamlParameters, read_comparison) {
-//     uint8_t flash[REQ_FLASH_SIZE];
-
-//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
-//                                                         NUM_STR_PARAMS, NUM_INT_PARAMS);
-//     auto res = yaml_params.read_from_dir(dir);
-//     ASSERT_EQ(res, LIBPARAMS_OK);
-//     for (uint8_t idx = 0; idx < IntParamsIndexes::INTEGER_PARAMS_AMOUNT; idx ++) {
-//         int32_t int_val = 0;
-//         memcpy(&int_val, flash + 4 * idx, 4);
-//         ASSERT_EQ(int_val, integer_desc_pool[idx].def);
-//     }
-//     for (uint8_t idx = 0; idx < NUM_OF_STR_PARAMS; idx ++) {
-//         auto offset = REQ_FLASH_SIZE - MAX_STRING_LENGTH * (NUM_OF_STR_PARAMS - idx);
-//         std::string str_val(reinterpret_cast<char*>(flash + offset),
-//         MAX_STRING_LENGTH);
-//         auto def = (char*)(string_desc_pool[idx].def);
-//         ASSERT_STREQ(str_val.c_str(), def);
-//     }
-// }
-
-
-// // Test Case 6. Check if created file is the same as initial_params yaml file generated
-// // by python script (/scripts/generate_random_params.py).
-// TEST(TestYamlParameters, write_comparison) {
-//     uint8_t flash[REQ_FLASH_SIZE];
-
-//     YamlParameters yaml_params = YamlParameters(flash, REQ_FLASH_SIZE, 1,
-//                                                         NUM_STR_PARAMS, NUM_INT_PARAMS);
-//     auto res = yaml_params.read_from_dir(dir);
-//     ASSERT_EQ(res, LIBPARAMS_OK);
-//     yaml_params.set_temp_file_name("written");
-//     res = yaml_params.write_to_dir(dir);
-//     ASSERT_EQ(res, LIBPARAMS_OK);
-
-//     auto file_name = dir + "/" + "init_params_0.yaml";
-//     std::ifstream init_storage_file;
-//     init_storage_file.open(file_name, std::ios_base::in);
-
-//     file_name = dir + "/" + "written_0.yaml";
-//     std::ifstream written_storage_file;
-//     written_storage_file.open(file_name, std::ios_base::in);
-
-
-//     std::string line;
-//     std::string written_line;
-//     while (std::getline(init_storage_file, line)) {
-//         std::getline(written_storage_file, written_line);
-//         ASSERT_STREQ(line.c_str(), written_line.c_str());
-//     }
-//     init_storage_file.close();
-//     written_storage_file.close();
-//     delete_file(file_name.c_str());
-// }
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Add `MemoryLayout` and `ParametersLayout` structures for ubuntu flash driver to avoid usage of parameters description pools in `YamlParameters`.
Updated YamlParamters logging with SimpleLogger.
Rewrote tests for the class with parametrised testing for YamlParameters initialization
Rewrote tests for the class with fixtures to analyze behaviour with known parameters