### PR TITLE
Generate string params enum

### DIFF
--- a/scripts/generate_params.py
+++ b/scripts/generate_params.py
@@ -26,6 +26,7 @@ class Generator:
         self.integers_array = ""
         self.integers_enums = ""
         self.strings_array = ""
+        self.strings_enums = ""
         self.strings_amount = 0
 
     def add_integer(self, param : IntegerParam):
@@ -47,8 +48,9 @@ class Generator:
     def add_string(self, param : StringParam):
         assert isinstance(param, StringParam)
         c_string = f"    {{{param.name :<32}, {param.default}, {param.mutability}}},\n"
-
+        h_string = f"    {param.enum_name},\n" if self.strings_amount > 0 else f"    {param.enum_name} = INTEGER_PARAMS_AMOUNT,\n"
         self.strings_array += c_string
+        self.strings_enums += h_string
         self.strings_amount += 1
 
     def generate(self):
@@ -81,6 +83,9 @@ class Generator:
                 "enum IntParamsIndexes {\n"
                 f"{self.integers_enums}\n"
                 "    INTEGER_PARAMS_AMOUNT\n"
+                "};\n"
+                "enum StrParamsIndexes {\n"
+                f"{self.strings_enums}\n"
                 "};\n"
                 f"#define NUM_OF_STR_PARAMS {self.strings_amount}\n"
             )

--- a/scripts/generate_params.py
+++ b/scripts/generate_params.py
@@ -52,6 +52,9 @@ class Generator:
         self.strings_array += c_string
         self.strings_enums += h_string
         self.strings_amount += 1
+        print(f"String: {param.name}")
+        print(f"Enum: {param.enum_name}")
+        print(f"Amount: {self.strings_amount}")
 
     def generate(self):
         if not os.path.exists(self.dir):
@@ -84,11 +87,17 @@ class Generator:
                 f"{self.integers_enums}\n"
                 "    INTEGER_PARAMS_AMOUNT\n"
                 "};\n"
-                "enum StrParamsIndexes {\n"
-                f"{self.strings_enums}\n"
-                "};\n"
-                f"#define NUM_OF_STR_PARAMS {self.strings_amount}\n"
+
             )
+            if self.strings_amount > 0:
+                hpp_content += (
+                    "enum StrParamsIndexes {\n"
+                    f"{self.strings_enums}\n"
+                    "    STRING_PARAMS_AMOUNT\n"
+                    "};\n"
+                )
+
+            hpp_content += f"#define NUM_OF_STR_PARAMS {self.strings_amount}\n"
             hpp_file.write(hpp_content)
 
 if __name__=="__main__":
@@ -120,12 +129,15 @@ if __name__=="__main__":
             for param_name in params:
                 data = params[param_name]
                 assert isinstance(data, dict), "Legacy style detected. Abort."
+                print(param_name)
+                print(data)
                 if 'type' not in data:
                     log_err(f"Type is not exist: {param_name}!")
                     sys.exit(1)
                 elif data['type'].lower() == "port":
                     gen.add_integer(IntegerParam.create_port_id(param_name, data['enum_base']))
-                    gen.add_string(StringParam.create_port_type(param_name, data['data_type']))
+                    gen.add_string(StringParam.create_port_type(param_name, data['data_type'],
+                                                                            data['enum_base']))
                 elif data['type'].lower() == "integer":
                     gen.add_integer(IntegerParam.create(param_name, data))
                 elif data['type'].lower() == "string":

--- a/scripts/generate_params.py
+++ b/scripts/generate_params.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2023 Dmitry Ponomarev <ponomarevda96@gmail.com>
-#
+#                    Anastasiia Stepanova <asiiapine@gmail.com>
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/scripts/generate_params.py
+++ b/scripts/generate_params.py
@@ -93,7 +93,6 @@ class Generator:
                 hpp_content += (
                     "enum StrParamsIndexes {\n"
                     f"{self.strings_enums}\n"
-                    "    STRING_PARAMS_AMOUNT\n"
                     "};\n"
                 )
 

--- a/scripts/generate_params.py
+++ b/scripts/generate_params.py
@@ -52,9 +52,6 @@ class Generator:
         self.strings_array += c_string
         self.strings_enums += h_string
         self.strings_amount += 1
-        print(f"String: {param.name}")
-        print(f"Enum: {param.enum_name}")
-        print(f"Amount: {self.strings_amount}")
 
     def generate(self):
         if not os.path.exists(self.dir):
@@ -128,8 +125,6 @@ if __name__=="__main__":
             for param_name in params:
                 data = params[param_name]
                 assert isinstance(data, dict), "Legacy style detected. Abort."
-                print(param_name)
-                print(data)
                 if 'type' not in data:
                     log_err(f"Type is not exist: {param_name}!")
                     sys.exit(1)

--- a/scripts/params.py
+++ b/scripts/params.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2023 Dmitry Ponomarev <ponomarevda96@gmail.com>
-#
+#                    Anastasiia Stepanova <asiiapine@gmail.com>
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/scripts/params.py
+++ b/scripts/params.py
@@ -115,10 +115,11 @@ class StringParam(BaseParam):
         return string_param
 
     @staticmethod
-    def create_port_type(param_name, data_type : str):
+    def create_port_type(param_name, data_type : str, enum_base : str):
         type_register = StringParam(
             name=f"\"{param_name}.type\"",
             default=f"\"{data_type}\"",
+            enum_name=f"{enum_base}_TYPE",
             mutability="IMMUTABLE"
         )
         return type_register

--- a/scripts/params.py
+++ b/scripts/params.py
@@ -15,9 +15,10 @@ from color_logging import log_warn, log_err
 @dataclass
 class BaseParam:
     name: str = ""
-    default: int = 0
+    default: int | str = 0
     note: str = ""
     mutability: str = "MUTABLE"
+    enum_name: str = ""
 
 @dataclass
 class IntegerParam(BaseParam):
@@ -26,7 +27,6 @@ class IntegerParam(BaseParam):
     - Cyphal    uavcan.register.Value.1.0.integer32
     - DroneCAN  uavcan.param.Value.integer_value
     """
-    enum_name: str = ""
     flags: str = ""
     min: int = 0
     max: int = 0
@@ -128,6 +128,7 @@ class StringParam(BaseParam):
         string_param = StringParam(
             name=f"\"{param_name}\"",
             default=f"\"{data['default']}\"",
+            enum_name=data['enum'],
             mutability=is_mutable(param_name, str(data['flags']))
         )
         if 'note' in data:
@@ -141,6 +142,7 @@ class StringParam(BaseParam):
         """Input example: param_name : ["data_type",  "ENUM_NAME"]"""
         string_param = StringParam(
             name=f"\"{param_name}\"",
+            enum_name=data[1],
             default=f"\"{data[3]}\"",
             mutability=is_mutable(param_name, str(data[2]))
         )


### PR DESCRIPTION
https://github.com/RaccoonlabDev/mini_v2_node/issues/113#issue-3096469273

Add StrParamsIndexes enum generation

```
// This file was automatically generated. Do not edit it manually.
// This Source Code Form is subject to the terms of the Mozilla Public
// License, v. 2.0. If a copy of the MPL was not distributed with this
// file, You can obtain one at https://mozilla.org/MPL/2.0/.
#pragma once
#include "storage.h"

enum IntParamsIndexes {
    PARAM_UAVCAN_NODE_ID,
    PARAM_LOG_LEVEL,
    PARAM_SYSTEM_CRC,
    PARAM_SYSTEM_CAN_TEMINATOR,
    PARAM_SYSTEM_PROTOCOL,
    PARAM_BOOTLOADER_INTERNAL,
    PARAM_STATS_ENG_TIME,
    PARAM_CRCT_BITMASK,
    PARAM_FEEDBACK_ESC_ENABLE,
    PARAM_FEEDBACK_ACTUATOR_ENABLE,
    PARAM_FEEDBACK_HARDPOINT_ENABLE,
    PARAM_PWM_CMD_TTL_MS,
    PARAM_PWM_FREQUENCY,
    PARAM_PWM_1_CH,
    PARAM_PWM_1_MIN,
    PARAM_PWM_1_MAX,
    PARAM_PWM_1_DEF,
    PARAM_PWM_2_CH,
    PARAM_PWM_2_MIN,
    PARAM_PWM_2_MAX,
    PARAM_PWM_2_DEF,
    PARAM_PWM_3_CH,
    PARAM_PWM_3_MIN,
    PARAM_PWM_3_MAX,
    PARAM_PWM_3_DEF,
    PARAM_PWM_4_CH,
    PARAM_PWM_4_MIN,
    PARAM_PWM_4_MAX,
    PARAM_PWM_4_DEF,
    PARAM_PWM_CMD_TYPE,

    INTEGER_PARAMS_AMOUNT
};
enum StrParamsIndexes {
    PARAM_NODE_DESCRIPTION = INTEGER_PARAMS_AMOUNT,
    PARAM_SYSTEM_NAME,

};
#define NUM_OF_STR_PARAMS 2
```