### PR TITLE
feat(rom): add check on erased flash

### DIFF
--- a/include/libparams/storage.h
+++ b/include/libparams/storage.h
@@ -179,6 +179,12 @@ uint8_t paramsSetStringValue(ParamIndex_t param_idx,
                              uint8_t str_len,
                              const StringParamValue_t param_value);
 
+/**
+ * @brief           Checks if params section was: mass erased/never flashed/sector erased
+ * @return          if params section appears to have all 0xFF.
+ */
+int8_t is_params_erased(bool* is_erased);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/libparams/storage.h
+++ b/include/libparams/storage.h
@@ -183,7 +183,7 @@ uint8_t paramsSetStringValue(ParamIndex_t param_idx,
  * @brief           Checks if params section was: mass erased/never flashed/sector erased
  * @return          if params section appears to have all 0xFF.
  */
-int8_t is_params_erased(bool* is_erased);
+int8_t paramsIsErased(bool* is_erased);
 
 #ifdef __cplusplus
 }

--- a/src/storage.c
+++ b/src/storage.c
@@ -212,8 +212,13 @@ int8_t paramsResetToDefault() {
             integer_values_pool[idx] = integer_desc_pool[idx].def;
         }
     }
+    
+    for (ParamIndex_t idx = 0; idx < strings_amount; ++idx) {
+        memcpy(string_values_pool[idx],
+               string_desc_pool[idx].def,
+               MAX_STRING_LENGTH);
+    }
 
-    memset(string_values_pool, 0x00, STR_POOL_SIZE);
     return LIBPARAMS_OK;
 }
 

--- a/src/storage.c
+++ b/src/storage.c
@@ -149,8 +149,6 @@ int8_t paramsLoad() {
         // 255 value is default value for stm32, '\0' for ubuntu
         if (string_values_pool[idx][0] == 255 || string_values_pool[idx][0] == '\0') {
             memcpy(string_values_pool[idx], string_desc_pool[idx].def, MAX_STRING_LENGTH);
-        } else {
-            break;
         }
     }
 
@@ -212,7 +210,7 @@ int8_t paramsResetToDefault() {
             integer_values_pool[idx] = integer_desc_pool[idx].def;
         }
     }
-    
+
     for (ParamIndex_t idx = 0; idx < strings_amount; ++idx) {
         memcpy(string_values_pool[idx],
                string_desc_pool[idx].def,

--- a/src/storage.c
+++ b/src/storage.c
@@ -330,6 +330,37 @@ const StringDesc_t* paramsGetStringDesc(ParamIndex_t param_idx) {
 
     return &string_desc_pool[param_idx];
 }
+int8_t is_params_erased(bool* is_erased) {
+    if (active_rom == NULL || is_erased == NULL) {
+        return LIBPARAMS_NOT_INITIALIZED;
+    }
+
+    uint8_t rom_data[64];
+    const uint32_t check_size = 256;
+    *is_erased = false;
+
+    for (uint32_t offset = 0; offset < check_size; offset += sizeof(rom_data)) {
+        size_t received_len = romRead(active_rom, offset,
+                rom_data, sizeof(rom_data));
+        for (uint8_t i = 0; i < received_len; i++) {
+            if (rom_data[i] != 0xFF) {
+                *is_erased = false;
+                return LIBPARAMS_OK;
+            }
+        }
+        // Means that we reached maximum of memory
+        if (received_len != sizeof(rom_data)) {
+            if ((size_t)offset + received_len < romGetAvailableMemory(active_rom)) {
+                return LIBPARAMS_UNKNOWN_HAL_ERROR;
+            }
+            *is_erased = true;
+            return LIBPARAMS_OK;
+        }
+    }
+    *is_erased = true;
+    
+    return LIBPARAMS_OK;
+}
 
 /************************************ PRIVATE FUNCTIONS AREA *************************************/
 

--- a/src/storage.c
+++ b/src/storage.c
@@ -344,7 +344,7 @@ int8_t is_params_erased(bool* is_erased) {
 
     for (uint32_t offset = 0; offset < check_size; offset += sizeof(rom_data)) {
         size_t received_len = romRead(active_rom, offset,
-                rom_data, sizeof(rom_data));
+                                      rom_data, sizeof(rom_data));
         for (uint8_t i = 0; i < received_len; i++) {
             if (rom_data[i] != 0xFF) {
                 *is_erased = false;
@@ -361,7 +361,7 @@ int8_t is_params_erased(bool* is_erased) {
         }
     }
     *is_erased = true;
-    
+
     return LIBPARAMS_OK;
 }
 

--- a/src/storage.c
+++ b/src/storage.c
@@ -333,7 +333,7 @@ const StringDesc_t* paramsGetStringDesc(ParamIndex_t param_idx) {
 
     return &string_desc_pool[param_idx];
 }
-int8_t is_params_erased(bool* is_erased) {
+int8_t paramsIsErased(bool* is_erased) {
     if (active_rom == NULL || is_erased == NULL) {
         return LIBPARAMS_NOT_INITIALIZED;
     }

--- a/tests/unit_tests/test_storage.cpp
+++ b/tests/unit_tests/test_storage.cpp
@@ -30,6 +30,21 @@ extern RomDriverInstance* standby_rom;
 extern IntegerParamValue_t integer_values_pool[];
 extern StringParamValue_t string_values_pool[];
 
+namespace {
+
+constexpr size_t TEST_ROM_SIZE = 2048U;
+uint8_t test_rom_data[TEST_ROM_SIZE];
+
+size_t testRomRead(uint8_t* data, size_t offset, size_t size) {
+    if (data == nullptr || offset + size > sizeof(test_rom_data)) {
+        return 0U;
+    }
+    memcpy(data, &test_rom_data[offset], size);
+    return size;
+}
+
+}  // namespace
+
 
 class RedundantRomStorageDriverTest : public ::testing::Test {
 protected:
@@ -142,16 +157,23 @@ TEST_F(SinglePageStorageDriverTest, loadDefaultsForErasedStringAfterValidString)
     memset(stored_strings[1], 0xFF, sizeof(stored_strings[1]));
 
     const size_t strings_offset =
-        romGetAvailableMemory(&rom) - sizeof(stored_strings);
-    romBeginWrite(&rom);
-    ASSERT_EQ(sizeof(stored_strings),
-              romWrite(&rom,
-                       strings_offset,
-                       reinterpret_cast<const uint8_t*>(stored_strings),
-                       sizeof(stored_strings)));
-    romEndWrite(&rom);
+        sizeof(test_rom_data) - sizeof(stored_strings);
+    memset(test_rom_data, 0xFF, sizeof(test_rom_data));
+    memcpy(&test_rom_data[strings_offset], stored_strings, sizeof(stored_strings));
 
-    ASSERT_EQ(LIBPARAMS_OK, paramsLoad());
+    FlashDriverOps test_flash_ops = *active_rom->flash;
+    test_flash_ops.read = testRomRead;
+    RomDriverInstance test_rom = *active_rom;
+    test_rom.flash = &test_flash_ops;
+    test_rom.first_page_idx = 0U;
+    test_rom.total_size = sizeof(test_rom_data);
+
+    RomDriverInstance* previous_rom = active_rom;
+    active_rom = &test_rom;
+    const int8_t load_status = paramsLoad();
+    active_rom = previous_rom;
+
+    ASSERT_EQ(LIBPARAMS_OK, load_status);
     EXPECT_EQ(0, memcmp(string_values_pool[0],
                         configured_name,
                         sizeof(configured_name)));
@@ -224,49 +246,51 @@ TEST_F(EmptyStorageDriverTest, resetParametersWithUninitializedParameters) {
 }
 
 TEST_F(SinglePageStorageDriverTest, detectErasedParamsInFirst256Bytes) {
-    uint8_t stored_data[257];
-    memset(stored_data, 0xFF, sizeof(stored_data));
+    memset(test_rom_data, 0xFF, sizeof(test_rom_data));
 
-    romBeginWrite(&rom);
-    ASSERT_EQ(sizeof(stored_data),
-              romWrite(&rom, 0, stored_data, sizeof(stored_data)));
-    romEndWrite(&rom);
+    FlashDriverOps test_flash_ops = *active_rom->flash;
+    test_flash_ops.read = testRomRead;
+    RomDriverInstance test_rom = *active_rom;
+    test_rom.flash = &test_flash_ops;
+    test_rom.first_page_idx = 0U;
+    test_rom.total_size = sizeof(test_rom_data);
+
+    RomDriverInstance* previous_rom = active_rom;
+    active_rom = &test_rom;
 
     bool is_erased = false;
-    ASSERT_EQ(LIBPARAMS_OK, is_params_erased(&is_erased));
-    EXPECT_TRUE(is_erased);
+    const int8_t erased_status = is_params_erased(&is_erased);
+    const bool all_ff_is_erased = is_erased;
 
-    stored_data[127] = 0x00;
-    romBeginWrite(&rom);
-    ASSERT_EQ(sizeof(stored_data),
-              romWrite(&rom, 0, stored_data, sizeof(stored_data)));
-    romEndWrite(&rom);
+    test_rom_data[127] = 0x00;
+    const int8_t programmed_status = is_params_erased(&is_erased);
+    const bool programmed_is_erased = is_erased;
 
-    ASSERT_EQ(LIBPARAMS_OK, is_params_erased(&is_erased));
-    EXPECT_FALSE(is_erased);
+    test_rom_data[127] = 0xFF;
+    test_rom_data[256] = 0x00;
+    const int8_t outside_status = is_params_erased(&is_erased);
+    const bool outside_is_erased = is_erased;
 
-    stored_data[127] = 0xFF;
-    stored_data[256] = 0x00;
-    romBeginWrite(&rom);
-    ASSERT_EQ(sizeof(stored_data),
-              romWrite(&rom, 0, stored_data, sizeof(stored_data)));
-    romEndWrite(&rom);
+    active_rom = previous_rom;
 
-    ASSERT_EQ(LIBPARAMS_OK, is_params_erased(&is_erased));
-    EXPECT_TRUE(is_erased);
+    EXPECT_EQ(LIBPARAMS_OK, erased_status);
+    EXPECT_TRUE(all_ff_is_erased);
+    EXPECT_EQ(LIBPARAMS_OK, programmed_status);
+    EXPECT_FALSE(programmed_is_erased);
+    EXPECT_EQ(LIBPARAMS_OK, outside_status);
+    EXPECT_TRUE(outside_is_erased);
 }
 
 TEST_F(SinglePageStorageDriverTest, detectErasedParamsInShortStorage) {
-    uint8_t stored_data[16];
-    memset(stored_data, 0xFF, sizeof(stored_data));
+    memset(test_rom_data, 0xFF, sizeof(test_rom_data));
 
-    romBeginWrite(&rom);
-    ASSERT_EQ(sizeof(stored_data),
-              romWrite(&rom, 0, stored_data, sizeof(stored_data)));
-    romEndWrite(&rom);
-
+    FlashDriverOps test_flash_ops = *active_rom->flash;
+    test_flash_ops.read = testRomRead;
     RomDriverInstance short_rom = *active_rom;
-    short_rom.total_size = sizeof(stored_data);
+    short_rom.flash = &test_flash_ops;
+    short_rom.first_page_idx = 0U;
+    short_rom.total_size = 16U;
+
     RomDriverInstance* full_rom = active_rom;
     active_rom = &short_rom;
 

--- a/tests/unit_tests/test_storage.cpp
+++ b/tests/unit_tests/test_storage.cpp
@@ -259,16 +259,16 @@ TEST_F(SinglePageStorageDriverTest, detectErasedParamsInFirst256Bytes) {
     active_rom = &test_rom;
 
     bool is_erased = false;
-    const int8_t erased_status = is_params_erased(&is_erased);
+    const int8_t erased_status = paramsIsErased(&is_erased);
     const bool all_ff_is_erased = is_erased;
 
     test_rom_data[127] = 0x00;
-    const int8_t programmed_status = is_params_erased(&is_erased);
+    const int8_t programmed_status = paramsIsErased(&is_erased);
     const bool programmed_is_erased = is_erased;
 
     test_rom_data[127] = 0xFF;
     test_rom_data[256] = 0x00;
-    const int8_t outside_status = is_params_erased(&is_erased);
+    const int8_t outside_status = paramsIsErased(&is_erased);
     const bool outside_is_erased = is_erased;
 
     active_rom = previous_rom;
@@ -295,7 +295,7 @@ TEST_F(SinglePageStorageDriverTest, detectErasedParamsInShortStorage) {
     active_rom = &short_rom;
 
     bool is_erased = false;
-    const int8_t status = is_params_erased(&is_erased);
+    const int8_t status = paramsIsErased(&is_erased);
     active_rom = full_rom;
 
     EXPECT_EQ(LIBPARAMS_OK, status);

--- a/tests/unit_tests/test_storage.cpp
+++ b/tests/unit_tests/test_storage.cpp
@@ -28,6 +28,7 @@ typedef enum {
 extern RomDriverInstance* active_rom;
 extern RomDriverInstance* standby_rom;
 extern IntegerParamValue_t integer_values_pool[];
+extern StringParamValue_t string_values_pool[];
 
 
 class RedundantRomStorageDriverTest : public ::testing::Test {
@@ -129,6 +130,38 @@ TEST_F(SinglePageStorageDriverTest, loadParametersSuccessfully) {
     ASSERT_EQ(LIBPARAMS_OK, paramsLoad());
     ASSERT_EQ(50, paramsGetIntegerValue(NODE_ID));
 }
+
+TEST_F(SinglePageStorageDriverTest, loadDefaultsForErasedStringAfterValidString) {
+    StringParamValue_t stored_strings[STRING_PARAMS_AMOUNT] = {};
+    const char configured_name[] = "Configured";
+    memcpy(stored_strings[0], configured_name, sizeof(configured_name));
+    memset(stored_strings[1], 0xFF, sizeof(stored_strings[1]));
+
+    const size_t strings_offset =
+        romGetAvailableMemory(&rom) - sizeof(stored_strings);
+    romBeginWrite(&rom);
+    ASSERT_EQ(sizeof(stored_strings),
+              romWrite(&rom,
+                       strings_offset,
+                       reinterpret_cast<const uint8_t*>(stored_strings),
+                       sizeof(stored_strings)));
+    romEndWrite(&rom);
+
+    ASSERT_EQ(LIBPARAMS_OK, paramsLoad());
+    EXPECT_EQ(0, memcmp(string_values_pool[0],
+                        configured_name,
+                        sizeof(configured_name)));
+
+    const StringDesc_t* second_string_desc =
+        paramsGetStringDesc(MAGNETOMETER_TYPE);
+    ASSERT_NE(second_string_desc, nullptr);
+    const size_t second_default_size =
+        strlen(reinterpret_cast<const char*>(second_string_desc->def)) + 1U;
+    EXPECT_EQ(0, memcmp(string_values_pool[1],
+                        second_string_desc->def,
+                        second_default_size));
+}
+
 // Test 2.2: Load Parameters with Uninitialized Parameters
 // Actually, it is better to return an error here
 TEST_F(EmptyStorageDriverTest, loadParametersSuccessfully) {
@@ -165,10 +198,79 @@ TEST_F(EmptyStorageDriverTest, saveParametersWithUninitializedParameters) {
 // Test Case 4: Reset Parameters to Default
 // Test 4.1: Reset Parameters Successfully
 TEST_F(SinglePageStorageDriverTest, resetParametersSuccessfully) {
+    const char configured_name[] = "Configured";
+    ASSERT_EQ(sizeof(configured_name) - 1U,
+              paramsSetStringValue(NODE_NAME,
+                                   sizeof(configured_name) - 1U,
+                                   reinterpret_cast<const uint8_t*>(configured_name)));
+
     ASSERT_EQ(LIBPARAMS_OK, paramsResetToDefault());
+
+    const StringDesc_t* node_name_desc = paramsGetStringDesc(NODE_NAME);
+    ASSERT_NE(node_name_desc, nullptr);
+    const size_t default_size =
+        strlen(reinterpret_cast<const char*>(node_name_desc->def)) + 1U;
+    EXPECT_EQ(0, memcmp(string_values_pool[0],
+                        node_name_desc->def,
+                        default_size));
 }
 TEST_F(EmptyStorageDriverTest, resetParametersWithUninitializedParameters) {
     ASSERT_EQ(LIBPARAMS_NOT_INITIALIZED, paramsResetToDefault());
+}
+
+TEST_F(SinglePageStorageDriverTest, detectErasedParamsInFirst256Bytes) {
+    uint8_t stored_data[257];
+    memset(stored_data, 0xFF, sizeof(stored_data));
+
+    romBeginWrite(&rom);
+    ASSERT_EQ(sizeof(stored_data),
+              romWrite(&rom, 0, stored_data, sizeof(stored_data)));
+    romEndWrite(&rom);
+
+    bool is_erased = false;
+    ASSERT_EQ(LIBPARAMS_OK, is_params_erased(&is_erased));
+    EXPECT_TRUE(is_erased);
+
+    stored_data[127] = 0x00;
+    romBeginWrite(&rom);
+    ASSERT_EQ(sizeof(stored_data),
+              romWrite(&rom, 0, stored_data, sizeof(stored_data)));
+    romEndWrite(&rom);
+
+    ASSERT_EQ(LIBPARAMS_OK, is_params_erased(&is_erased));
+    EXPECT_FALSE(is_erased);
+
+    stored_data[127] = 0xFF;
+    stored_data[256] = 0x00;
+    romBeginWrite(&rom);
+    ASSERT_EQ(sizeof(stored_data),
+              romWrite(&rom, 0, stored_data, sizeof(stored_data)));
+    romEndWrite(&rom);
+
+    ASSERT_EQ(LIBPARAMS_OK, is_params_erased(&is_erased));
+    EXPECT_TRUE(is_erased);
+}
+
+TEST_F(SinglePageStorageDriverTest, detectErasedParamsInShortStorage) {
+    uint8_t stored_data[16];
+    memset(stored_data, 0xFF, sizeof(stored_data));
+
+    romBeginWrite(&rom);
+    ASSERT_EQ(sizeof(stored_data),
+              romWrite(&rom, 0, stored_data, sizeof(stored_data)));
+    romEndWrite(&rom);
+
+    RomDriverInstance short_rom = *active_rom;
+    short_rom.total_size = sizeof(stored_data);
+    RomDriverInstance* full_rom = active_rom;
+    active_rom = &short_rom;
+
+    bool is_erased = false;
+    const int8_t status = is_params_erased(&is_erased);
+    active_rom = full_rom;
+
+    EXPECT_EQ(LIBPARAMS_OK, status);
+    EXPECT_TRUE(is_erased);
 }
 
 

--- a/tests/unit_tests/test_storage.cpp
+++ b/tests/unit_tests/test_storage.cpp
@@ -78,7 +78,8 @@ protected:
 // Test Case 1: Initialization of Parameters
 // Test 1.1: Initialize with Valid Inputs
 TEST_F(EmptyStorageDriverTest, initializeWithValidInput) {
-    ASSERT_EQ(LIBPARAMS_OK, paramsInit(ubuntuFlashGetOps(), INTEGER_PARAMS_AMOUNT, STRING_PARAMS_AMOUNT, -1, 1));
+    ASSERT_EQ(LIBPARAMS_OK, paramsInit(ubuntuFlashGetOps(), INTEGER_PARAMS_AMOUNT, STRING_PARAMS_AMOUNT,
+                                       -1, 1));
 }
 // Test 1.2: Initialize with zero params
 TEST_F(EmptyStorageDriverTest, initializeWithZeroParams) {
@@ -90,15 +91,18 @@ TEST_F(EmptyStorageDriverTest, initializeWithTooMuchParams) {
 }
 // Test 1.4: Initialize with Zero Pages
 TEST_F(EmptyStorageDriverTest, initializeZeroPages) {
-    ASSERT_EQ(LIBPARAMS_UNKNOWN_ERROR, paramsInit(ubuntuFlashGetOps(), INTEGER_PARAMS_AMOUNT, STRING_PARAMS_AMOUNT, 0, 0));
+    ASSERT_EQ(LIBPARAMS_UNKNOWN_ERROR, paramsInit(ubuntuFlashGetOps(), INTEGER_PARAMS_AMOUNT,
+                                                  STRING_PARAMS_AMOUNT, 0, 0));
 }
 // Test 1.5: Initialize with Invalid Page Index
 TEST_F(EmptyStorageDriverTest, initializeWithInvalidaPageIndex) {
-    ASSERT_EQ(LIBPARAMS_UNKNOWN_ERROR, paramsInit(ubuntuFlashGetOps(), INTEGER_PARAMS_AMOUNT, STRING_PARAMS_AMOUNT, -1, 2));
+    ASSERT_EQ(LIBPARAMS_UNKNOWN_ERROR, paramsInit(ubuntuFlashGetOps(), INTEGER_PARAMS_AMOUNT,
+                                                  STRING_PARAMS_AMOUNT, -1, 2));
 }
 // Test 1.6: Initialize with null flash ops
 TEST_F(EmptyStorageDriverTest, initializeWithNullFlashOps) {
-    ASSERT_EQ(LIBPARAMS_WRONG_ARGS, paramsInit(nullptr, INTEGER_PARAMS_AMOUNT, STRING_PARAMS_AMOUNT, -1, 1));
+    ASSERT_EQ(LIBPARAMS_WRONG_ARGS, paramsInit(nullptr, INTEGER_PARAMS_AMOUNT, STRING_PARAMS_AMOUNT, -1,
+                                               1));
 }
 
 // Test Case 2: Load Parameters
@@ -173,7 +177,8 @@ TEST_F(EmptyStorageDriverTest, loadParametersSuccessfully) {
 // Test 3.1: Save Parameters Successfully
 TEST_F(EmptyStorageDriverTest, saveParametersSuccessfully) {
     // Normal
-    ASSERT_EQ(LIBPARAMS_OK, paramsInit(ubuntuFlashGetOps(), INTEGER_PARAMS_AMOUNT, STRING_PARAMS_AMOUNT, -1, 1));
+    ASSERT_EQ(LIBPARAMS_OK, paramsInit(ubuntuFlashGetOps(), INTEGER_PARAMS_AMOUNT, STRING_PARAMS_AMOUNT,
+                                       -1, 1));
     ASSERT_EQ(LIBPARAMS_OK, paramsSave());
 
     // Zero integers is ok


### PR DESCRIPTION
This PR:
- Adds check if flash was: mass erased/never flashed/sector erased;
- Fixes param reset function to reset strings as well instead of setting them to 0x00;
- Fixes paramsLoad where not all strings were checked on valid value